### PR TITLE
Allow /issue-init without args using current branch

### DIFF
--- a/.cursor/commands/issue-init.md
+++ b/.cursor/commands/issue-init.md
@@ -3,22 +3,31 @@
 Create an `*_original.md` file in `.issueflows/01-current-issues` from a GitHub issue.
 
 ## Input
-The user will provide one of:
+The user may provide one of:
 - an issue number (e.g. `123`)
 - or a full GitHub issue URL
 
-Use the text provided after this slash command as the issue reference.
+The text after this slash command is the **issue reference**. It may also be **empty or only whitespace** (user ran `/issue-init` with no arguments).
 
 ## Steps
 
 0. Check that the required folders exist (`.issueflows/00-tools`, `.issueflows/01-current-issues`, `.issueflows/02-partly-solved-issues`, `.issueflows/03-solved-issues`). If not, create them after asking for permission.
 
-1. Resolve the issue reference from the user input.
-   - If input is a full URL, extract `owner`, `repo`, and `issue number`.
-   - If input is only an issue number:
-     - derive `owner/repo` from `git remote` (prefer `origin`)
-     - support both SSH and HTTPS remote URL formats
-     - if parsing fails, ask the user for either full issue URL or `owner/repo`
+1. Resolve the issue reference.
+   - **A. No non-empty issue reference** (missing or whitespace-only after the command):
+     - Run `git branch --show-current` to get the current branch name.
+     - If the branch name is empty **or** equals `main` or `master` (**case-insensitive**): **stop**. Tell the user the issue cannot be inferred from this branch and they must run `/issue-init` with an issue number, a full GitHub issue URL, or `owner/repo/#number`.
+     - Else if the branch name matches an **issue-style branch**: ASCII digits at the start, then `-`, then at least one more character (example: `42-fix-login-bug`). Let `NN` be the leading digit sequence.
+       - Ask: "You have not provided an issue reference. Should I use issue #NN from the current branch `<branchname>`?" (use the real branch name).
+       - If the user **confirms**, treat `NN` as the issue number and continue with the bullets under **B** as if the user had typed only `NN`.
+       - If the user **declines** or is **unclear**, ask for an issue number, full URL, or `owner/repo`, and do not proceed until you have a clear reference.
+     - Else (branch does not match that pattern): **do not guess.** Ask the user for an issue number, full GitHub issue URL, or `owner/repo/#number`, and do not proceed until they provide it.
+   - **B. You have a concrete issue reference** (from user input or from **A** after confirmation):
+     - If the reference is a full URL, extract `owner`, `repo`, and `issue number`.
+     - If the reference is only an issue number:
+       - derive `owner/repo` from `git remote` (prefer `origin`)
+       - support both SSH and HTTPS remote URL formats
+       - if parsing fails, ask the user for either full issue URL or `owner/repo`
 
 2. Fetch issue data using GitHub CLI (explicit repo if needed):
    - title
@@ -61,6 +70,7 @@ Use the text provided after this slash command as the issue reference.
 Report:
 - issue number fetched
 - repository used (`owner/repo`)
+- if the issue number was inferred from the current branch after the user confirmed in step **1 A**, state the branch name and that `#NN` was inferred from it
 - file path created
 - archive moves performed (source -> destination, grouped by issue number)
 - whether the operation succeeded
@@ -73,9 +83,10 @@ Report:
   - move pre-existing issue files from `.issueflows/01-current-issues` to `.issueflows/02-partly-solved-issues` or `.issueflows/03-solved-issues` according to the archive rule above
 - If `.issueflows/01-current-issues` does not exist, report an error and stop.
 - If archive destination directories do not exist, report an error and stop.
-- Prefer deterministic behavior: always state which repo was resolved before writing the file.
+- Prefer deterministic behavior: always state which repo was resolved before writing the file (including when the issue number came from branch inference).
 
 ## Example invocations
 - `/issue-init 123`
 - `/issue-init https://github.com/owner/repo/issues/123`
 - `/issue-init owner/repo/#123`
+- `/issue-init` (no trailing text: on an issue-style branch like `123-fix-bug`, ask for confirmation then proceed as for issue `123`)

--- a/.issueflows/03-solved-issues/issue2_original.md
+++ b/.issueflows/03-solved-issues/issue2_original.md
@@ -1,0 +1,11 @@
+# Issue #2: Enhance issue-init so that it selects issue related to current branch if no issue number is given
+
+Source: https://github.com/jepegit/issue-flow/issues/2
+
+## Original issue text
+
+the command /issue-init expects at minimum an issue number before starting. If we already are on a branch, and it is created from an issue (has the branch name NN-issue-text) it will often be the case that the issue NN is the one the user wants to work on.
+
+To be in line with the simplicity principle, the agent should ask something like "you have not provided any issue reference, should I look for issues related to the current branch?
+
+Sometimes it is an obvious mistake from the user (just forgot it), for example if the branch is called main or master. Then it is no point in continuing, just inform the user that, sorry, you cant continue until we know what issue we are working on.

--- a/.issueflows/03-solved-issues/issue2_status.md
+++ b/.issueflows/03-solved-issues/issue2_status.md
@@ -1,0 +1,11 @@
+# Issue #2 — status
+
+## Work completed
+
+- [x] Extend `/issue-init` command (template + `.cursor/commands`) for empty reference: `git branch --show-current`, refuse inference on `main`/`master`, ask on `NN-slug` branches, otherwise ask for explicit reference.
+- [x] Output/constraints mention branch inference when used.
+- [x] Tests for rendered `issue-init.md`; docs workflow + `init.py` hint.
+
+## Done
+
+- [x] Done

--- a/docs/cursor-issue-workflow.md
+++ b/docs/cursor-issue-workflow.md
@@ -14,7 +14,7 @@ This repo uses three Cursor **slash commands** under `.cursor/commands/` that li
 
 **When:** You have a GitHub issue you want to work on (or archive older "current" issues before starting a new one).
 
-**What you pass:** Either an issue number (e.g. `42`) or a full GitHub issue URL. The assistant resolves `owner/repo` from `git remote origin` when you only pass a number.
+**What you pass:** Either an issue number (e.g. `42`), a full GitHub issue URL, or nothing after `/issue-init`—in that case, on a branch named like `42-short-description`, the assistant may ask to use `#42` from the branch (and refuses to guess on `main`/`master`). The assistant resolves `owner/repo` from `git remote origin` when you only pass a number.
 
 **What happens:**
 

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -67,7 +67,11 @@ def run_init(project_root: Path, force: bool = False) -> None:
     if not written_files and not skipped_files:
         console.print("[bold]Nothing to do.[/bold]")
 
-    console.print("\n[dim]Run [bold]/issue-init <number>[/bold] in Cursor to start tracking a GitHub issue.[/dim]\n")
+    console.print(
+        "\n[dim]Run [bold]/issue-init <number>[/bold] or [bold]/issue-init[/bold] "
+        "(on a branch like [bold]42-slug[/bold], after confirmation) in Cursor "
+        "to start tracking a GitHub issue.[/dim]\n"
+    )
 
 
 def _create_issueflow_dirs(project_root: Path, settings: Settings) -> None:

--- a/src/issue_flow/templates/commands/issue-init.md.j2
+++ b/src/issue_flow/templates/commands/issue-init.md.j2
@@ -3,22 +3,31 @@
 Create an `*_original.md` file in `{{ issueflows_dir }}/{{ current_issues_folder }}` from a GitHub issue.
 
 ## Input
-The user will provide one of:
+The user may provide one of:
 - an issue number (e.g. `123`)
 - or a full GitHub issue URL
 
-Use the text provided after this slash command as the issue reference.
+The text after this slash command is the **issue reference**. It may also be **empty or only whitespace** (user ran `/issue-init` with no arguments).
 
 ## Steps
 
 0. Check that the required folders exist (`{{ issueflows_dir }}/{{ tools_folder }}`, `{{ issueflows_dir }}/{{ current_issues_folder }}`, `{{ issueflows_dir }}/{{ partly_solved_folder }}`, `{{ issueflows_dir }}/{{ solved_folder }}`). If not, create them after asking for permission.
 
-1. Resolve the issue reference from the user input.
-   - If input is a full URL, extract `owner`, `repo`, and `issue number`.
-   - If input is only an issue number:
-     - derive `owner/repo` from `git remote` (prefer `origin`)
-     - support both SSH and HTTPS remote URL formats
-     - if parsing fails, ask the user for either full issue URL or `owner/repo`
+1. Resolve the issue reference.
+   - **A. No non-empty issue reference** (missing or whitespace-only after the command):
+     - Run `git branch --show-current` to get the current branch name.
+     - If the branch name is empty **or** equals `main` or `master` (**case-insensitive**): **stop**. Tell the user the issue cannot be inferred from this branch and they must run `/issue-init` with an issue number, a full GitHub issue URL, or `owner/repo/#number`.
+     - Else if the branch name matches an **issue-style branch**: ASCII digits at the start, then `-`, then at least one more character (example: `42-fix-login-bug`). Let `NN` be the leading digit sequence.
+       - Ask: "You have not provided an issue reference. Should I use issue #NN from the current branch `<branchname>`?" (use the real branch name).
+       - If the user **confirms**, treat `NN` as the issue number and continue with the bullets under **B** as if the user had typed only `NN`.
+       - If the user **declines** or is **unclear**, ask for an issue number, full URL, or `owner/repo`, and do not proceed until you have a clear reference.
+     - Else (branch does not match that pattern): **do not guess.** Ask the user for an issue number, full GitHub issue URL, or `owner/repo/#number`, and do not proceed until they provide it.
+   - **B. You have a concrete issue reference** (from user input or from **A** after confirmation):
+     - If the reference is a full URL, extract `owner`, `repo`, and `issue number`.
+     - If the reference is only an issue number:
+       - derive `owner/repo` from `git remote` (prefer `origin`)
+       - support both SSH and HTTPS remote URL formats
+       - if parsing fails, ask the user for either full issue URL or `owner/repo`
 
 2. Fetch issue data using GitHub CLI (explicit repo if needed):
    - title
@@ -61,6 +70,7 @@ Use the text provided after this slash command as the issue reference.
 Report:
 - issue number fetched
 - repository used (`owner/repo`)
+- if the issue number was inferred from the current branch after the user confirmed in step **1 A**, state the branch name and that `#NN` was inferred from it
 - file path created
 - archive moves performed (source -> destination, grouped by issue number)
 - whether the operation succeeded
@@ -73,9 +83,10 @@ Report:
   - move pre-existing issue files from `{{ issueflows_dir }}/{{ current_issues_folder }}` to `{{ issueflows_dir }}/{{ partly_solved_folder }}` or `{{ issueflows_dir }}/{{ solved_folder }}` according to the archive rule above
 - If `{{ issueflows_dir }}/{{ current_issues_folder }}` does not exist, report an error and stop.
 - If archive destination directories do not exist, report an error and stop.
-- Prefer deterministic behavior: always state which repo was resolved before writing the file.
+- Prefer deterministic behavior: always state which repo was resolved before writing the file (including when the issue number came from branch inference).
 
 ## Example invocations
 - `/issue-init 123`
 - `/issue-init https://github.com/owner/repo/issues/123`
 - `/issue-init owner/repo/#123`
+- `/issue-init` (no trailing text: on an issue-style branch like `123-fix-bug`, ask for confirmation then proceed as for issue `123`)

--- a/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
+++ b/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
@@ -14,7 +14,7 @@ This repo uses three Cursor **slash commands** under `{{ cursor_dir }}/commands/
 
 **When:** You have a GitHub issue you want to work on (or archive older "current" issues before starting a new one).
 
-**What you pass:** Either an issue number (e.g. `42`) or a full GitHub issue URL. The assistant resolves `owner/repo` from `git remote origin` when you only pass a number.
+**What you pass:** Either an issue number (e.g. `42`), a full GitHub issue URL, or nothing after `/issue-init`—in that case, on a branch named like `42-short-description`, the assistant may ask to use `#42` from the branch (and refuses to guess on `main`/`master`). The assistant resolves `owner/repo` from `git remote origin` when you only pass a number.
 
 **What happens:**
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -94,6 +94,15 @@ def test_init_templates_reference_issueflows_dir(tmp_path: Path) -> None:
         assert ".issueflows/" in content, f"{filename} should reference .issueflows/"
 
 
+def test_init_issue_init_documents_branch_inference(tmp_path: Path) -> None:
+    """issue-init.md should describe resolving an issue from the current branch when no args."""
+    run_init(tmp_path)
+    content = (tmp_path / ".cursor" / "commands" / "issue-init.md").read_text(encoding="utf-8")
+    assert "git branch --show-current" in content
+    assert "You have not provided an issue reference" in content
+    assert "issue-style branch" in content
+
+
 def test_init_detects_project_name(tmp_path: Path) -> None:
     """If a pyproject.toml exists, its name should appear in the rule file."""
     pyproject = tmp_path / "pyproject.toml"


### PR DESCRIPTION
This change updates the `/issue-init` Cursor command (Jinja template and committed copy under `.cursor/commands`) so the agent can run it with no trailing text: it reads `git branch --show-current`, refuses to infer an issue on `main`/`master`, offers issue #NN from `NN-slug` branch names after explicit confirmation, and otherwise asks for a number or URL.

Workflow documentation and the `issue-flow init` console hint mention the same behavior. Tests assert the rendered `issue-init.md` documents branch inference.

**How to test:** `uv run pytest`

Closes #2

Made with [Cursor](https://cursor.com)