### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-flow"
-version = "0.1.3"
+version = "0.1.4"
 description = "Agents should behave. Let them follow the issue flow."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "issue-flow"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
Version bump (pyproject + lockfile) that was committed on `4-update-issueflow-for-already-initialized-projects` after #5 merged.

This PR applies that change on top of current `main` so history stays linear.

Made with [Cursor](https://cursor.com)