### PR TITLE
Add Agent Skills scaffold for issue-flow init/update

### DIFF
--- a/.cursor/skills/issueflow-issue-close/SKILL.md
+++ b/.cursor/skills/issueflow-issue-close/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: issueflow-issue-close
+description: >-
+  Run the /issue-close workflow: verify tests, update issue status and folder
+  locations, commit, push, and open a PR with a clear summary.
+disable-model-invocation: true
+---
+
+# issue-flow — issue close (`/issue-close`)
+
+Follow this skill when the user wants to **finish and land** work: tests, issue-folder updates, git, and PR. Match `.cursor/commands/issue-close.md`.
+
+## When to use
+
+- The user runs `/issue-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
+
+## Instructions
+
+1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes.
+
+2. **Issue tracking** — Under `.issueflows/01-current-issues/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `.issueflows/03-solved-issues/`. If partially resolved, move to `.issueflows/02-partly-solved-issues/`. Follow any stricter rules in `.cursor/rules/issueflow-rules.mdc` if present.
+
+3. **Commit** — Stage intentionally; write a commit message in full sentences describing what changed and why.
+
+4. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
+
+5. **Push** — Push to the remote the project uses (typically `origin`).
+
+6. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+
+7. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+
+## Constraints
+
+- Do not skip failing tests without the user’s explicit agreement.
+- Prefer focused commits; do not rewrite unrelated history unless asked.

--- a/.cursor/skills/issueflow-issue-init/SKILL.md
+++ b/.cursor/skills/issueflow-issue-init/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: issueflow-issue-init
+description: >-
+  Run the /issue-init workflow: resolve GitHub issue reference, fetch with gh,
+  write issue<number>_original.md under .issueflows/01-current-issues/,
+  and archive other current issues by done status.
+disable-model-invocation: true
+---
+
+# issue-flow — issue init (`/issue-init`)
+
+Follow this skill when the user wants to **capture a GitHub issue locally** using the same rules as `.cursor/commands/issue-init.md`.
+
+## When to use
+
+- The user runs `/issue-init`, mentions **issue-init**, or asks to pull an issue into `.issueflows/01-current-issues/`.
+- You need a repeatable checklist without opening the command file.
+
+## Instructions
+
+1. **Folders** — Ensure `.issueflows/00-tools/`, `.issueflows/01-current-issues/`, `.issueflows/02-partly-solved-issues/`, and `.issueflows/03-solved-issues/` exist (create only if the user allows; never delete issue markdown).
+
+2. **Resolve the reference**
+   - **URL** — Parse `owner`, `repo`, issue number.
+   - **Number only** — Use `git remote get-url origin` (HTTPS or SSH) to derive `owner/repo`. If parsing fails, ask for a full URL or `owner/repo`.
+   - **Empty / whitespace** — Run `git branch --show-current`. If empty or `main`/`master` (case-insensitive), **stop** and ask for a number, URL, or `owner/repo/#n`. If the branch matches `^\d+-.+`, ask once whether to use that leading issue number; do not proceed without a clear yes/no.
+
+3. **Fetch** — `gh issue view <n> --repo owner/repo --json title,body,url,number`. On failure, report the error and suggest `gh auth login`.
+
+4. **Archive** — In `.issueflows/01-current-issues/`, group files by issue number (`issue121_*`). For each group **other than** the issue being created: move the whole group to `.issueflows/03-solved-issues/` only if a status file for that issue contains a checked **Done** line matching `- [x] Done` (case-insensitive on “done”). Otherwise move to `.issueflows/02-partly-solved-issues/`. If no status file or checkbox is unclear, treat as **not done**.
+
+5. **Write** — Create `.issueflows/01-current-issues/issue<number>_original.md` with:
+
+   ```markdown
+   # Issue #<number>: <title>
+
+   Source: <url>
+
+   ## Original issue text
+
+   <body exactly as returned by GitHub>
+   ```
+
+   Preserve the body **byte-for-byte** (including trailing newlines).
+
+6. **Conflicts** — If `issue<number>_original.md` already exists, do not overwrite silently; ask the user.
+
+7. **Report** — Summarize number, `owner/repo`, branch inference (if used), path written, archive moves (source → destination), and success or failure.
+
+## Constraints
+
+- Allowed file operations: create/update the target `*_original.md`, and move pre-existing issue groups per the archive rules. Do not modify unrelated project files.
+- Use UTF-8 for markdown output.

--- a/.cursor/skills/issueflow-issue-start/SKILL.md
+++ b/.cursor/skills/issueflow-issue-start/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: issueflow-issue-start
+description: >-
+  Run the /issue-start workflow: pick the current issue markdown, plan (with
+  confirmation when not in plan mode), guard scope, then implement with project
+  conventions (e.g. uv run).
+disable-model-invocation: true
+---
+
+# issue-flow — issue start (`/issue-start`)
+
+Follow this skill when the user wants to **begin implementation** from issue notes, matching `.cursor/commands/issue-start.md` and project rules.
+
+## When to use
+
+- The user runs `/issue-start`, mentions **issue-start**, or asks to implement from `.issueflows/01-current-issues/`.
+- Work should follow the issue-flow markdown workflow and stay aligned with `.cursor/rules/issueflow-rules.mdc` when present.
+
+## Instructions
+
+1. **Select the issue** — Read `.issueflows/01-current-issues/`. If there is no `*_original.md` (or multiple ambiguous groups), **stop** and ask which issue to use.
+
+2. **Plan first** — Produce a concrete plan (steps, files touched, tests). If you are **not** in plan mode, **stop and ask for explicit confirmation** before implementing, per the command definition.
+
+3. **Scope check** — If the plan is broad, propose splitting into phases and ask whether to narrow scope before coding.
+
+4. **Implement** — Execute the confirmed plan. Prefer minimal, focused diffs. Match existing code style and tooling.
+
+5. **Project conventions**
+   - Run Python via **`uv run`** (scripts, pytest, tools), not bare `python`, unless the user overrides.
+   - Manage dependencies with **`uv add` / `uv remove` / `uv sync`** only.
+   - After meaningful progress, update or create a status markdown file under `.issueflows/01-current-issues/` (e.g. `issue<number>_status.md`) with an explicit **Done** checkbox: `- [ ] Done` until fully resolved, then `- [x] Done`.
+
+6. **Reporting** — Summarize what changed, what remains, and where the issue docs live.
+
+## Constraints
+
+- Do not invent issue text; treat `*_original.md` as read-only source of requirements unless the user asks to edit it.
+- Do not move issue files between `01-` / `02-` / `03-` folders during `/issue-start` unless the user explicitly asked for that housekeeping.

--- a/.issueflows/03-solved-issues/issue1_original.md
+++ b/.issueflows/03-solved-issues/issue1_original.md
@@ -1,0 +1,13 @@
+# Issue #1: commands versus skills
+
+Source: https://github.com/jepegit/issue-flow/issues/1
+
+## Original issue text
+
+Agentic IDEs seem to make a distinction between commands and skills. Lets check if we also can set up a template-solution for issue-flow related skills.
+
+1. investigate (browse the web if needed) how we can implement skills
+2. if skills are a real thing, suggest 3 skills that would enhance issue-flow. Ask for feedback.
+3. if skills are a real thing, implement templating machinery for creating skills (through issufelow init) and include the skills that we have selected.
+
+

--- a/.issueflows/03-solved-issues/issue1_status.md
+++ b/.issueflows/03-solved-issues/issue1_status.md
@@ -1,0 +1,10 @@
+# Issue #1 — status: commands versus skills
+
+## Done checklist
+
+- [x] Done
+
+## Notes
+
+- Confirmed phased plan; implemented three bundled Agent Skills (`issueflow-issue-init`, `issueflow-issue-start`, `issueflow-issue-close`) and wired them into `issue-flow init` / `issue-flow update` via `TEMPLATE_MANIFEST`.
+- Documented skills in README and `docs/cursor-issue-workflow.md` template.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ your-project/
       issue-init.md         # /issue-init — fetch a GitHub issue locally
       issue-start.md        # /issue-start — plan and implement
       issue-close.md        # /issue-close — test, commit, push, PR
+    skills/                 # Optional Agent Skills (explicit / @ invoke)
+      issueflow-issue-init/SKILL.md
+      issueflow-issue-start/SKILL.md
+      issueflow-issue-close/SKILL.md
     rules/
       issueflow-rules.mdc   # Always-on Cursor rule for the workflow
   docs/
@@ -31,6 +35,8 @@ The three Cursor slash commands give agents a repeatable flow:
 1. `/issue-init 42` — pulls GitHub issue #42 into `.issueflows/01-current-issues/` and archives older issues.
 2. `/issue-start` — reads the issue file, plans, and implements.
 3. `/issue-close` — runs tests, updates status files, commits, pushes, and opens a PR.
+
+The matching **Agent Skills** (under `.cursor/skills/`) carry the same workflows for on-demand use with `/issueflow-issue-init`, `/issueflow-issue-start`, or `/issueflow-issue-close` (see [Cursor Agent Skills](https://cursor.com/docs/context/skills)).
 
 ## Installation
 

--- a/docs/cursor-issue-workflow.md
+++ b/docs/cursor-issue-workflow.md
@@ -10,6 +10,20 @@ This repo uses three Cursor **slash commands** under `.cursor/commands/` that li
 
 ---
 
+## Agent Skills (optional)
+
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `.cursor/skills/` — longer, on-demand playbooks that mirror the three commands:
+
+| Skill folder | Invoke (examples) | Role |
+|--------------|-------------------|------|
+| `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init` (resolve reference, `gh`, archive, write `*_original.md`). |
+| `issueflow-issue-start` | `/issueflow-issue-start` | Plan + confirmation + scope + implement from `.issueflows/01-current-issues/`. |
+| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, status checkboxes, move issue docs, commit, push, PR. |
+
+Each skill sets `disable-model-invocation: true` so it is included when you **explicitly** invoke it, not on every chat. See [Agent Skills](https://cursor.com/docs/context/skills) in the Cursor docs.
+
+---
+
 ## 1. `/issue-init` — capture the issue locally
 
 **When:** You have a GitHub issue you want to work on (or archive older "current" issues before starting a new one).
@@ -80,4 +94,4 @@ Commit → push → PR → merge
     └── issue docs in .issueflows/03-solved-issues/ or .issueflows/02-partly-solved-issues/ when appropriate
 ```
 
-The command definitions are the source of truth: `.cursor/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. This document is a readable overview only.
+The command definitions are the source of truth: `.cursor/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. The skill packages under `.cursor/skills/` repeat the same workflows for explicit invocation. This document is a readable overview only.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -62,6 +62,7 @@ issue-flow/
     templates/            # Templates rendered by "init"
       commands/           # Cursor slash command templates
       rules/              # Cursor rule templates
+      skills/             # Cursor Agent Skill templates (SKILL.md per skill)
       docs/               # Documentation templates
   tests/                  # Test files
   docs/                   # Documentation (you are here)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-flow"
-version = "0.1.4"
+version = "0.2.0"
 description = "Agents should behave. Let them follow the issue flow."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -67,7 +67,7 @@ def _already_initialized(
 
 
 def run_init(project_root: Path, force: bool = False) -> None:
-    """Scaffold .issueflows/ directories and .cursor/ config files.
+    """Scaffold .issueflows/ directories and .cursor/ config (commands, rules, skills).
 
     Re-running without ``force`` skips existing manifest outputs so local
     edits and issue markdown under ``.issueflows/`` are preserved. Manifest
@@ -112,12 +112,14 @@ def run_init(project_root: Path, force: bool = False) -> None:
     console.print(
         "\n[dim]Run [bold]/issue-init <number>[/bold] or [bold]/issue-init[/bold] "
         "(on a branch like [bold]42-slug[/bold], after confirmation) in Cursor "
-        "to start tracking a GitHub issue.[/dim]\n"
+        "to start tracking a GitHub issue. "
+        "Optional Agent Skills live under [bold].cursor/skills/[/bold] "
+        "([bold]/issueflow-issue-init[/bold], etc.).[/dim]\n"
     )
 
 
 def run_update(project_root: Path) -> None:
-    """Refresh packaged scaffold files (Cursor commands, rule, workflow doc).
+    """Refresh packaged scaffold files (commands, rule, skills, workflow doc).
 
     Overwrites every path in ``TEMPLATE_MANIFEST`` with the templates from the
     installed package. Does not read or delete other files under ``.issueflows/``

--- a/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
+++ b/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
@@ -10,6 +10,20 @@ This repo uses three Cursor **slash commands** under `{{ cursor_dir }}/commands/
 
 ---
 
+## Agent Skills (optional)
+
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ cursor_dir }}/skills/` — longer, on-demand playbooks that mirror the three commands:
+
+| Skill folder | Invoke (examples) | Role |
+|--------------|-------------------|------|
+| `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init` (resolve reference, `gh`, archive, write `*_original.md`). |
+| `issueflow-issue-start` | `/issueflow-issue-start` | Plan + confirmation + scope + implement from `{{ issueflows_dir }}/{{ current_issues_folder }}/`. |
+| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, status checkboxes, move issue docs, commit, push, PR. |
+
+Each skill sets `disable-model-invocation: true` so it is included when you **explicitly** invoke it, not on every chat. See [Agent Skills](https://cursor.com/docs/context/skills) in the Cursor docs.
+
+---
+
 ## 1. `/issue-init` — capture the issue locally
 
 **When:** You have a GitHub issue you want to work on (or archive older "current" issues before starting a new one).
@@ -80,4 +94,4 @@ Commit → push → PR → merge
     └── issue docs in {{ issueflows_dir }}/{{ solved_folder }}/ or {{ issueflows_dir }}/{{ partly_solved_folder }}/ when appropriate
 ```
 
-The command definitions are the source of truth: `{{ cursor_dir }}/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. This document is a readable overview only.
+The command definitions are the source of truth: `{{ cursor_dir }}/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. The skill packages under `{{ cursor_dir }}/skills/` repeat the same workflows for explicit invocation. This document is a readable overview only.

--- a/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
@@ -1,0 +1,36 @@
+---
+name: issueflow-issue-close
+description: >-
+  Run the /issue-close workflow: verify tests, update issue status and folder
+  locations, commit, push, and open a PR with a clear summary.
+disable-model-invocation: true
+---
+
+# issue-flow — issue close (`/issue-close`)
+
+Follow this skill when the user wants to **finish and land** work: tests, issue-folder updates, git, and PR. Match `{{ cursor_dir }}/commands/issue-close.md`.
+
+## When to use
+
+- The user runs `/issue-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
+
+## Instructions
+
+1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes.
+
+2. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ cursor_dir }}/rules/issueflow-rules.mdc` if present.
+
+3. **Commit** — Stage intentionally; write a commit message in full sentences describing what changed and why.
+
+4. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
+
+5. **Push** — Push to the remote the project uses (typically `origin`).
+
+6. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+
+7. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+
+## Constraints
+
+- Do not skip failing tests without the user’s explicit agreement.
+- Prefer focused commits; do not rewrite unrelated history unless asked.

--- a/src/issue_flow/templates/skills/issueflow_issue_init/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_init/SKILL.md.j2
@@ -1,0 +1,53 @@
+---
+name: issueflow-issue-init
+description: >-
+  Run the /issue-init workflow: resolve GitHub issue reference, fetch with gh,
+  write issue<number>_original.md under {{ issueflows_dir }}/{{ current_issues_folder }}/,
+  and archive other current issues by done status.
+disable-model-invocation: true
+---
+
+# issue-flow — issue init (`/issue-init`)
+
+Follow this skill when the user wants to **capture a GitHub issue locally** using the same rules as `{{ cursor_dir }}/commands/issue-init.md`.
+
+## When to use
+
+- The user runs `/issue-init`, mentions **issue-init**, or asks to pull an issue into `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
+- You need a repeatable checklist without opening the command file.
+
+## Instructions
+
+1. **Folders** — Ensure `{{ issueflows_dir }}/{{ tools_folder }}/`, `{{ issueflows_dir }}/{{ current_issues_folder }}/`, `{{ issueflows_dir }}/{{ partly_solved_folder }}/`, and `{{ issueflows_dir }}/{{ solved_folder }}/` exist (create only if the user allows; never delete issue markdown).
+
+2. **Resolve the reference**
+   - **URL** — Parse `owner`, `repo`, issue number.
+   - **Number only** — Use `git remote get-url origin` (HTTPS or SSH) to derive `owner/repo`. If parsing fails, ask for a full URL or `owner/repo`.
+   - **Empty / whitespace** — Run `git branch --show-current`. If empty or `main`/`master` (case-insensitive), **stop** and ask for a number, URL, or `owner/repo/#n`. If the branch matches `^\d+-.+`, ask once whether to use that leading issue number; do not proceed without a clear yes/no.
+
+3. **Fetch** — `gh issue view <n> --repo owner/repo --json title,body,url,number`. On failure, report the error and suggest `gh auth login`.
+
+4. **Archive** — In `{{ issueflows_dir }}/{{ current_issues_folder }}/`, group files by issue number (`issue121_*`). For each group **other than** the issue being created: move the whole group to `{{ issueflows_dir }}/{{ solved_folder }}/` only if a status file for that issue contains a checked **Done** line matching `- [x] Done` (case-insensitive on “done”). Otherwise move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. If no status file or checkbox is unclear, treat as **not done**.
+
+5. **Write** — Create `{{ issueflows_dir }}/{{ current_issues_folder }}/issue<number>_original.md` with:
+
+   ```markdown
+   # Issue #<number>: <title>
+
+   Source: <url>
+
+   ## Original issue text
+
+   <body exactly as returned by GitHub>
+   ```
+
+   Preserve the body **byte-for-byte** (including trailing newlines).
+
+6. **Conflicts** — If `issue<number>_original.md` already exists, do not overwrite silently; ask the user.
+
+7. **Report** — Summarize number, `owner/repo`, branch inference (if used), path written, archive moves (source → destination), and success or failure.
+
+## Constraints
+
+- Allowed file operations: create/update the target `*_original.md`, and move pre-existing issue groups per the archive rules. Do not modify unrelated project files.
+- Use UTF-8 for markdown output.

--- a/src/issue_flow/templates/skills/issueflow_issue_start/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_start/SKILL.md.j2
@@ -1,0 +1,39 @@
+---
+name: issueflow-issue-start
+description: >-
+  Run the /issue-start workflow: pick the current issue markdown, plan (with
+  confirmation when not in plan mode), guard scope, then implement with project
+  conventions (e.g. uv run).
+disable-model-invocation: true
+---
+
+# issue-flow — issue start (`/issue-start`)
+
+Follow this skill when the user wants to **begin implementation** from issue notes, matching `{{ cursor_dir }}/commands/issue-start.md` and project rules.
+
+## When to use
+
+- The user runs `/issue-start`, mentions **issue-start**, or asks to implement from `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
+- Work should follow the issue-flow markdown workflow and stay aligned with `{{ cursor_dir }}/rules/issueflow-rules.mdc` when present.
+
+## Instructions
+
+1. **Select the issue** — Read `{{ issueflows_dir }}/{{ current_issues_folder }}/`. If there is no `*_original.md` (or multiple ambiguous groups), **stop** and ask which issue to use.
+
+2. **Plan first** — Produce a concrete plan (steps, files touched, tests). If you are **not** in plan mode, **stop and ask for explicit confirmation** before implementing, per the command definition.
+
+3. **Scope check** — If the plan is broad, propose splitting into phases and ask whether to narrow scope before coding.
+
+4. **Implement** — Execute the confirmed plan. Prefer minimal, focused diffs. Match existing code style and tooling.
+
+5. **Project conventions**
+   - Run Python via **`uv run`** (scripts, pytest, tools), not bare `python`, unless the user overrides.
+   - Manage dependencies with **`uv add` / `uv remove` / `uv sync`** only.
+   - After meaningful progress, update or create a status markdown file under `{{ issueflows_dir }}/{{ current_issues_folder }}/` (e.g. `issue<number>_status.md`) with an explicit **Done** checkbox: `- [ ] Done` until fully resolved, then `- [x] Done`.
+
+6. **Reporting** — Summarize what changed, what remains, and where the issue docs live.
+
+## Constraints
+
+- Do not invent issue text; treat `*_original.md` as read-only source of requirements unless the user asks to edit it.
+- Do not move issue files between `01-` / `02-` / `03-` folders during `/issue-start` unless the user explicitly asked for that housekeeping.

--- a/src/issue_flow/templating.py
+++ b/src/issue_flow/templating.py
@@ -75,6 +75,18 @@ TEMPLATE_MANIFEST: list[tuple[str, str]] = [
     ("commands/issue-close.md.j2", "{cursor_dir}/commands/issue-close.md"),
     ("rules/issueflow-rules.mdc.j2", "{cursor_dir}/rules/issueflow-rules.mdc"),
     ("docs/cursor-issue-workflow.md.j2", "{docs_dir}/cursor-issue-workflow.md"),
+    (
+        "skills/issueflow_issue_init/SKILL.md.j2",
+        "{cursor_dir}/skills/issueflow-issue-init/SKILL.md",
+    ),
+    (
+        "skills/issueflow_issue_start/SKILL.md.j2",
+        "{cursor_dir}/skills/issueflow-issue-start/SKILL.md",
+    ),
+    (
+        "skills/issueflow_issue_close/SKILL.md.j2",
+        "{cursor_dir}/skills/issueflow-issue-close/SKILL.md",
+    ),
 ]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -44,6 +44,20 @@ def test_init_creates_cursor_commands(tmp_path: Path) -> None:
     assert (commands_dir / "issue-close.md").is_file()
 
 
+def test_init_creates_cursor_skills(tmp_path: Path) -> None:
+    """Running init should create bundled Agent Skills under .cursor/skills/."""
+    run_init(tmp_path)
+
+    skills = tmp_path / ".cursor" / "skills"
+    for name in ("issueflow-issue-init", "issueflow-issue-start", "issueflow-issue-close"):
+        skill_file = skills / name / "SKILL.md"
+        assert skill_file.is_file(), f"expected {skill_file}"
+        text = skill_file.read_text(encoding="utf-8")
+        assert text.startswith("---")
+        assert f"name: {name}" in text
+        assert "disable-model-invocation: true" in text
+
+
 def test_init_creates_cursor_rule(tmp_path: Path) -> None:
     run_init(tmp_path)
     rule = tmp_path / ".cursor" / "rules" / "issueflow-rules.mdc"

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -52,5 +52,5 @@ def test_resolve_output_path() -> None:
     assert path == Path(".cursor/commands/issue-init.md")
 
 
-def test_manifest_has_five_entries() -> None:
-    assert len(TEMPLATE_MANIFEST) == 5
+def test_manifest_entry_count() -> None:
+    assert len(TEMPLATE_MANIFEST) == 8

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -36,6 +36,20 @@ def test_update_preserves_issue_markdown(tmp_path: Path) -> None:
     assert issue_file.read_text(encoding="utf-8") == distinctive
 
 
+def test_update_overwrites_skill_files(tmp_path: Path) -> None:
+    """update should refresh packaged skills like other manifest outputs."""
+    run_init(tmp_path)
+
+    skill = tmp_path / ".cursor" / "skills" / "issueflow-issue-init" / "SKILL.md"
+    skill.write_text("custom skill", encoding="utf-8")
+
+    run_update(tmp_path)
+
+    content = skill.read_text(encoding="utf-8")
+    assert content != "custom skill"
+    assert "name: issueflow-issue-init" in content
+
+
 def test_update_recreates_removed_subdir(tmp_path: Path) -> None:
     """If an issueflows subdir was removed, update should recreate it."""
     run_init(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "issue-flow"
-version = "0.1.4"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

This change adds three bundled [Cursor Agent Skills](https://cursor.com/docs/context/skills) that mirror the existing slash-command workflow (`/issue-init`, `/issue-start`, `/issue-close`). They are installed under `.cursor/skills/` when consumers run `issue-flow init` or `issue-flow update`.

## How to test

- `uv run pytest`
- `uv run ruff check src/ tests/`
- In a temp directory: `uv run issue-flow init /path/to/dir` and confirm `.cursor/skills/issueflow-issue-*/SKILL.md` exist.

Closes #1

Made with [Cursor](https://cursor.com)