### PR TITLE
Streamline /issue-init guidance for body text and newlines

### DIFF
--- a/.cursor/commands/issue-init.md
+++ b/.cursor/commands/issue-init.md
@@ -9,6 +9,11 @@ The user may provide one of:
 
 The text after this slash command is the **issue reference**. It may also be **empty or only whitespace** (user ran `/issue-init` with no arguments).
 
+## Agent efficiency
+- Run the flow once; do not re-fetch or re-run tools only to diff the written file against the API (for example, no extra `gh` calls or scripts to compare bytes).
+- Do **not** spend effort on trailing newlines, byte-identical file endings, or CRLF vs LF. A normal markdown file with a final newline is fine.
+- "Preserve the issue body exactly as returned by GitHub" means the **body text** from the fetch: paste it into the template in **step 5** and move on. No second-pass verification or newline normalization.
+
 ## Steps
 
 0. Check that the required folders exist (`.issueflows/00-tools`, `.issueflows/01-current-issues`, `.issueflows/02-partly-solved-issues`, `.issueflows/03-solved-issues`). If not, create them after asking for permission.
@@ -76,7 +81,7 @@ Report:
 - whether the operation succeeded
 
 ## Constraints
-- Preserve the issue body exactly as returned by GitHub.
+- Preserve the issue body **text** exactly as returned by GitHub (see **Agent efficiency**; do not optimize for trailing newlines or line-ending style).
 - Use UTF-8 markdown.
 - Allowed file modifications for this command:
   - create/update the target `issue<number>_original.md`

--- a/.issueflows/03-solved-issues/issue7_original.md
+++ b/.issueflows/03-solved-issues/issue7_original.md
@@ -1,0 +1,7 @@
+# Issue #7: trailing newlines
+
+Source: https://github.com/jepegit/issue-flow/issues/7
+
+## Original issue text
+
+The agents seem to spend a lot of time during /issue-init on unimportant stuff like fixing trailing newlines. That is not needed. Update the slash command so that it becomes more efficient, and that it does not care about trailing newlines.

--- a/.issueflows/03-solved-issues/issue7_status.md
+++ b/.issueflows/03-solved-issues/issue7_status.md
@@ -1,0 +1,5 @@
+# Issue #7 status
+
+- [x] Done
+
+Updated `.cursor/commands/issue-init.md` with **Agent efficiency** rules and a clarified body-preservation constraint so agents do not spend time on trailing newlines or redundant verification.


### PR DESCRIPTION
This updates the `/issue-init` Cursor command with an **Agent efficiency** section so agents do not re-fetch or diff files for byte-identical endings, and do not spend time on trailing newlines or CRLF vs LF. The preserve-body constraint now refers to the substantive **text** from GitHub.

Issue tracking: adds `issue7_original.md` and `issue7_status.md` under `.issueflows/03-solved-issues/`.

**How to test:** `uv run pytest` (all tests should pass; change is documentation and issue-flow metadata only).

Closes #7

Made with [Cursor](https://cursor.com)