### PR TITLE
Optional /issue-close version bump and 0.2.1 release

### DIFF
--- a/.cursor/commands/issue-close.md
+++ b/.cursor/commands/issue-close.md
@@ -4,7 +4,15 @@ Run this when implementation is done and you are ready to land the work.
 
 ## Input
 
-Optional: branch name, PR title, or anything special (e.g. draft PR, skip issue doc update, commit all changes).
+Optional text after the command (same line). Examples:
+
+- **No extra text** — close the issue without bumping the package version.
+- **`bump`** or **`patch`** — bump the **patch** semver (e.g. `1.2.0` → `1.2.1`).
+- **`bump minor`** or **`minor`** — bump **minor**.
+- **`bump major`** or **`major`** — bump **major**.
+- **Free text** — if it clearly asks to release or bump the version, infer `patch`, `minor`, or `major` from wording (e.g. “bugfix release” → patch); if unclear, ask once.
+
+Other optional notes still apply: branch name, PR title, draft PR, skip issue doc update, commit all changes, etc.
 
 ## Typical steps
 
@@ -12,23 +20,29 @@ Optional: branch name, PR title, or anything special (e.g. draft PR, skip issue 
    - Run tests and any checks you rely on (e.g. `uv run pytest`).
    - Skim the diff so the commit matches what you intend to ship.
 
-2. **Issue tracking in the repo** (see project rules under `.issueflows/01-current-issues`)
+2. **Optional version bump** (only if the user asked for it in the command input)
+   - Read `.cursor/skills/issueflow-version-bump/SKILL.md` and follow it.
+   - From the project root, run `uv version --bump patch`, `uv version --bump minor`, or `uv version --bump major` according to the input rules above.
+   - Do this **before** updating issue markdown and **before** commit / push / PR so the new version is in the tree that gets merged.
+   - If the project has no bumpable `pyproject.toml` version, skip and say so; continue with the remaining steps.
+
+3. **Issue tracking in the repo** (see project rules under `.issueflows/01-current-issues`)
    - Update the status file for this issue: clear checklist, remaining work, and use `- [x] Done` only when fully resolved.
    - If the issue is fully resolved, move its markdown files from `.issueflows/01-current-issues` to `.issueflows/03-solved-issues`. If partially resolved, move to `.issueflows/02-partly-solved-issues`.
 
-3. **Commit and fix merge conflicts**
-   - Unless told to commit all, stage the right files (avoid unrelated changes).
+4. **Commit and fix merge conflicts**
+   - Unless told to commit all, stage the right files (avoid unrelated changes). Include `pyproject.toml` (and `uv.lock` if it changed) when a version bump ran.
    - Write a commit message that states what changed and why in normal sentences.
    - Make sure you have pulled the last changes from the default branch (e.g. `main`) and check for and fix merge conflicts.
 
-4. **Push**
+5. **Push**
    - Push your branch to `origin` (or the remote you use).
 
-5. **Pull request**
+6. **Pull request**
    - Open a PR against the default branch (e.g. `main`).
    - Describe the change, how to test it, and link the GitHub issue (e.g. `Closes #123` or `Refs #123` in the PR body).
 
-6. **After review**
+7. **After review**
    - Address feedback, push updates, and merge when approved and CI is green.
 
 ## Output

--- a/.cursor/commands/issue-init.md
+++ b/.cursor/commands/issue-init.md
@@ -9,11 +9,6 @@ The user may provide one of:
 
 The text after this slash command is the **issue reference**. It may also be **empty or only whitespace** (user ran `/issue-init` with no arguments).
 
-## Agent efficiency
-- Run the flow once; do not re-fetch or re-run tools only to diff the written file against the API (for example, no extra `gh` calls or scripts to compare bytes).
-- Do **not** spend effort on trailing newlines, byte-identical file endings, or CRLF vs LF. A normal markdown file with a final newline is fine.
-- "Preserve the issue body exactly as returned by GitHub" means the **body text** from the fetch: paste it into the template in **step 5** and move on. No second-pass verification or newline normalization.
-
 ## Steps
 
 0. Check that the required folders exist (`.issueflows/00-tools`, `.issueflows/01-current-issues`, `.issueflows/02-partly-solved-issues`, `.issueflows/03-solved-issues`). If not, create them after asking for permission.
@@ -81,7 +76,7 @@ Report:
 - whether the operation succeeded
 
 ## Constraints
-- Preserve the issue body **text** exactly as returned by GitHub (see **Agent efficiency**; do not optimize for trailing newlines or line-ending style).
+- Preserve the issue body exactly as returned by GitHub.
 - Use UTF-8 markdown.
 - Allowed file modifications for this command:
   - create/update the target `issue<number>_original.md`

--- a/.cursor/skills/issueflow-issue-close/SKILL.md
+++ b/.cursor/skills/issueflow-issue-close/SKILL.md
@@ -1,34 +1,47 @@
 ---
 name: issueflow-issue-close
 description: >-
-  Run the /issue-close workflow: verify tests, update issue status and folder
-  locations, commit, push, and open a PR with a clear summary.
+  Run the /issue-close workflow: verify tests, optional uv semver bump, update
+  issue status and folder locations, commit, push, and open a PR with a clear summary.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue close (`/issue-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, issue-folder updates, git, and PR. Match `.cursor/commands/issue-close.md`.
+Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR. Match `.cursor/commands/issue-close.md`.
 
 ## When to use
 
 - The user runs `/issue-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
 
+## Optional version bump (command input)
+
+If the user included text after `/issue-close` that requests a version bump:
+
+- **`bump`** or **`patch`** → `uv version --bump patch`
+- **`bump minor`** or **`minor`** → `uv version --bump minor`
+- **`bump major`** or **`major`** → `uv version --bump major`
+- Otherwise infer **patch** / **minor** / **major** from natural language; ask once if ambiguous.
+
+When a bump applies: read `.cursor/skills/issueflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+
 ## Instructions
 
 1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes.
 
-2. **Issue tracking** — Under `.issueflows/01-current-issues/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `.issueflows/03-solved-issues/`. If partially resolved, move to `.issueflows/02-partly-solved-issues/`. Follow any stricter rules in `.cursor/rules/issueflow-rules.mdc` if present.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `.cursor/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
-3. **Commit** — Stage intentionally; write a commit message in full sentences describing what changed and why.
+3. **Issue tracking** — Under `.issueflows/01-current-issues/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `.issueflows/03-solved-issues/`. If partially resolved, move to `.issueflows/02-partly-solved-issues/`. Follow any stricter rules in `.cursor/rules/issueflow-rules.mdc` if present.
 
-4. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
+4. **Commit** — Stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
 
-5. **Push** — Push to the remote the project uses (typically `origin`).
+5. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
 
-6. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+6. **Push** — Push to the remote the project uses (typically `origin`).
 
-7. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+7. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+
+8. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
 
 ## Constraints
 

--- a/.cursor/skills/issueflow-version-bump/SKILL.md
+++ b/.cursor/skills/issueflow-version-bump/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: issueflow-version-bump
+description: >-
+  Bump semantic version in pyproject.toml using uv (patch, minor, or major)
+  from the project root.
+disable-model-invocation: true
+---
+
+# issue-flow — version bump
+
+Use when the user wants to **bump the project version** with **uv** before landing work (often invoked from `/issue-close`).
+
+## When to use
+
+- The user asks for a **patch**, **minor**, or **major** semver bump.
+- The repo is a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field (standard for packages using issue-flow).
+
+## Preconditions
+
+1. Run from the **project root** (the directory that contains `pyproject.toml`).
+2. If `pyproject.toml` is missing or has no `[project]` `version`, **skip** the bump, explain why, and continue other work (for example the rest of `/issue-close`) without failing the whole flow.
+
+## Command
+
+Use **only** `uv` with a bump level (`patch`, `minor`, or `major`). Example for a patch release (e.g. `1.2.0` → `1.2.1`):
+
+```bash
+uv version --bump patch
+```
+
+Use `uv version --bump minor` or `uv version --bump major` when that is what the user requested.
+
+## After bumping
+
+1. Confirm the new version in `pyproject.toml` (or from the `uv` command output).
+2. When committing later, stage **`pyproject.toml`**. If **`uv.lock`** changed as well, stage it too; otherwise do not assume it changed.
+
+## Constraints
+
+- Do not substitute `pip` or hand-edit the version unless `uv version` fails and the user agrees to an alternative.
+- Prefer one clear bump level; if the user is ambiguous, ask once rather than guessing **major**.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv sync
 
       - name: Lint
-        run: uv run ruff check src/ tests/
+        run: uv run ruff check src/ tests/ scripts/
 
       - name: Run tests
         run: uv run pytest -v

--- a/.issueflows/03-solved-issues/issue10_original.md
+++ b/.issueflows/03-solved-issues/issue10_original.md
@@ -1,0 +1,27 @@
+# Issue #10: enhance issue-close with ability to bump version number
+
+Source: https://github.com/jepegit/issue-flow/issues/10
+
+## Original issue text
+
+It would be cool if we could add ability for issue-close to also bump the version number. 
+
+Add a skill for bumping version number:
+
+The command should be like this for bumping the semantic versioning version number (this example is for bumping from e.g. 1.2.0 to 1.2.1)
+
+`uv version --bump patch`
+
+Add the ability for issue-close to bump version number if the user asks for it while issuing "/issue-close". The bump should be done before creating the final pull request (to make sure that the new version number is a part of the code when pulling)
+
+Example:
+
+`/issue-close bump`:  bumps patch
+
+`/issue-close patch`:  bumps patch
+
+`/issue-close bump minor`:  bumps minor
+
+`/issue-close <some txt describing that the user would like bumping the version number>`:  bumps according to the description
+
+

--- a/.issueflows/03-solved-issues/issue10_status.md
+++ b/.issueflows/03-solved-issues/issue10_status.md
@@ -1,0 +1,17 @@
+# Issue #10 — status
+
+## Scope
+
+Enhance `/issue-close` with optional semver bump via `uv version --bump`, packaged `issueflow-version-bump` skill, template and doc updates, tests, and maintainer helper `scripts/update_issueflow_setup.py` (local scaffold refresh).
+
+## Checklist
+
+- [x] Version bump skill and manifest entry
+- [x] `issue-close` command + `issueflow-issue-close` skill ordering (bump after tests, before commit/PR)
+- [x] Workflow doc template and README alignment
+- [x] Tests and CI ruff coverage for `scripts/`
+- [x] Patch release `0.2.1` via `/issue-close bump`
+
+## Done
+
+- [x] Done

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ your-project/
       issueflow-issue-init/SKILL.md
       issueflow-issue-start/SKILL.md
       issueflow-issue-close/SKILL.md
+      issueflow-version-bump/SKILL.md
     rules/
       issueflow-rules.mdc   # Always-on Cursor rule for the workflow
   docs/
@@ -34,9 +35,9 @@ The three Cursor slash commands give agents a repeatable flow:
 
 1. `/issue-init 42` — pulls GitHub issue #42 into `.issueflows/01-current-issues/` and archives older issues.
 2. `/issue-start` — reads the issue file, plans, and implements.
-3. `/issue-close` — runs tests, updates status files, commits, pushes, and opens a PR.
+3. `/issue-close` — runs tests, optionally bumps version with `uv version --bump`, updates status files, commits, pushes, and opens a PR.
 
-The matching **Agent Skills** (under `.cursor/skills/`) carry the same workflows for on-demand use with `/issueflow-issue-init`, `/issueflow-issue-start`, or `/issueflow-issue-close` (see [Cursor Agent Skills](https://cursor.com/docs/context/skills)).
+The matching **Agent Skills** (under `.cursor/skills/`) carry the same workflows for on-demand use with `/issueflow-issue-init`, `/issueflow-issue-start`, `/issueflow-issue-close`, or `@issueflow-version-bump` when you need only the bump steps (see [Cursor Agent Skills](https://cursor.com/docs/context/skills)).
 
 ## Installation
 

--- a/docs/cursor-issue-workflow.md
+++ b/docs/cursor-issue-workflow.md
@@ -6,19 +6,20 @@ This repo uses three Cursor **slash commands** under `.cursor/commands/` that li
 |--------|------|------|
 | `/issue-init` | `issue-init.md` | Pull an issue from GitHub into the repo as a local markdown file and tidy older current issues. |
 | `/issue-start` | `issue-start.md` | Plan and implement the work described in `.issueflows/01-current-issues/`. |
-| `/issue-close` | `issue-close.md` | Finish: tests, issue-folder housekeeping, commit, push, PR. |
+| `/issue-close` | `issue-close.md` | Finish: tests, optional semver bump (`uv version --bump …`), issue-folder housekeeping, commit, push, PR. |
 
 ---
 
 ## Agent Skills (optional)
 
-`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `.cursor/skills/` — longer, on-demand playbooks that mirror the three commands:
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `.cursor/skills/` — longer, on-demand playbooks that mirror the slash commands (plus a small helper for version bumps):
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
 | `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init` (resolve reference, `gh`, archive, write `*_original.md`). |
 | `issueflow-issue-start` | `/issueflow-issue-start` | Plan + confirmation + scope + implement from `.issueflows/01-current-issues/`. |
-| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, status checkboxes, move issue docs, commit, push, PR. |
+| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, optional bump, status checkboxes, move issue docs, commit, push, PR. |
+| `issueflow-version-bump` | `@issueflow-version-bump` (often used from `/issue-close`) | Bump `[project]` version in `pyproject.toml` via `uv version --bump patch|minor|major`. |
 
 Each skill sets `disable-model-invocation: true` so it is included when you **explicitly** invoke it, not on every chat. See [Agent Skills](https://cursor.com/docs/context/skills) in the Cursor docs.
 
@@ -62,16 +63,24 @@ Each skill sets `disable-model-invocation: true` so it is included when you **ex
 
 **When:** Implementation is done and you want to ship (commit, push, PR).
 
-**What you pass:** Optional notes (branch name, PR title, draft PR, or "skip issue doc update").
+**What you pass:** Optional notes (branch name, PR title, draft PR, or "skip issue doc update"). You can also ask for a **semver bump** in the same line, for example:
+
+- `/issue-close bump` or `/issue-close patch` — bump **patch** (e.g. `1.2.0` → `1.2.1`) using `uv version --bump patch`.
+- `/issue-close bump minor` — bump **minor**.
+- `/issue-close bump major` or `/issue-close major` — bump **major**.
+- Free text that clearly describes the bump level — the assistant infers patch vs minor vs major.
+
+The bump runs **after** tests and **before** issue-folder moves and **before** commit / push / PR so the PR includes the new version. If `pyproject.toml` has no bumpable version, the assistant skips the bump and continues.
 
 **Typical steps the assistant follows:**
 
 1. **Sanity check** — e.g. `uv run pytest`, review the diff.
-2. **Issue folders** — update status markdown; use `- [x] Done` only when fully resolved. Move completed issue files from `.issueflows/01-current-issues/` to `.issueflows/03-solved-issues/`, or partly done work to `.issueflows/02-partly-solved-issues/` (see project rules).
-3. **Commit** — focused staging and a clear message.
-4. **Push** — to your usual remote (e.g. `origin`).
-5. **Pull request** — open against the default branch; link the GitHub issue (`Closes #n` / `Refs #n`).
-6. **After review** — address comments, merge when ready.
+2. **Optional version bump** — if requested, follow `.cursor/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump …` from the project root.
+3. **Issue folders** — update status markdown; use `- [x] Done` only when fully resolved. Move completed issue files from `.issueflows/01-current-issues/` to `.issueflows/03-solved-issues/`, or partly done work to `.issueflows/02-partly-solved-issues/` (see project rules).
+4. **Commit** — focused staging and a clear message (include `pyproject.toml` / `uv.lock` if the bump changed them).
+5. **Push** — to your usual remote (e.g. `origin`).
+6. **Pull request** — open against the default branch; link the GitHub issue (`Closes #n` / `Refs #n`).
+7. **After review** — address comments, merge when ready.
 
 **Result:** Short summary of commit, push, and PR link (or what is blocked).
 
@@ -89,7 +98,7 @@ GitHub issue
 Code + tests (+ status updates during work)
     │  /issue-close
     ▼
-Commit → push → PR → merge
+Optional `uv version --bump …` → Commit → push → PR → merge
     │
     └── issue docs in .issueflows/03-solved-issues/ or .issueflows/02-partly-solved-issues/ when appropriate
 ```

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -37,13 +37,14 @@ Here are the commands you'll use most often:
 |------|---------|
 | Run tests | `uv run pytest` |
 | Run tests (verbose) | `uv run pytest -v` |
-| Lint the code | `uv run ruff check src/ tests/` |
-| Auto-fix lint issues | `uv run ruff check --fix src/ tests/` |
-| Format the code | `uv run ruff format src/ tests/` |
+| Lint the code | `uv run ruff check src/ tests/ scripts/` |
+| Auto-fix lint issues | `uv run ruff check --fix src/ tests/ scripts/ scripts/` |
+| Format the code | `uv run ruff format src/ tests/ scripts/` |
 | Add a dependency | `uv add <package>` |
 | Add a dev dependency | `uv add --dev <package>` |
 | Run the CLI locally | `uv run issue-flow --help` |
 | Refresh scaffold in a test project (same as installed package templates) | `uv run issue-flow update <DIR>` |
+| Refresh **this** repo's `.cursor/` and generated workflow doc from templates | `uv run scripts/update_issueflow_setup.py` |
 
 Always use `uv run` instead of calling `python` directly. This makes sure you're using the right virtual environment and dependencies.
 
@@ -53,6 +54,7 @@ Always use `uv run` instead of calling `python` directly. This makes sure you're
 
 ```text
 issue-flow/
+  scripts/                # Maintainer helpers (e.g. refresh local Cursor scaffold)
   src/issue_flow/         # The actual package
     __init__.py           # Version string
     cli.py                # Command-line interface (typer)
@@ -103,13 +105,13 @@ uv run pytest -k "test_init_creates_directories"
 We use [ruff](https://docs.astral.sh/ruff/) for both linting and formatting. Before you commit, run:
 
 ```bash
-uv run ruff check src/ tests/
+uv run ruff check src/ tests/ scripts/
 ```
 
 If ruff reports issues it can fix automatically:
 
 ```bash
-uv run ruff check --fix src/ tests/
+uv run ruff check --fix src/ tests/ scripts/
 ```
 
 ---
@@ -138,7 +140,7 @@ Here's the full process, step by step.
 
 ```bash
 uv run pytest -v
-uv run ruff check src/ tests/
+uv run ruff check src/ tests/ scripts/
 ```
 
 Don't skip this. If tests fail, the publish workflow will also fail.
@@ -222,7 +224,8 @@ uv sync
 
 # Develop
 uv run pytest
-uv run ruff check src/ tests/
+uv run ruff check src/ tests/ scripts/
+uv run scripts/update_issueflow_setup.py
 uv run issue-flow init /tmp/test-project
 
 # Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-flow"
-version = "0.2.0"
+version = "0.2.1"
 description = "Agents should behave. Let them follow the issue flow."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scripts/update_issueflow_setup.py
+++ b/scripts/update_issueflow_setup.py
@@ -1,0 +1,20 @@
+"""Refresh this repository's issue-flow scaffold from packaged templates.
+
+Equivalent to running ``uv run issue-flow update .`` from the repo root, but
+works no matter what directory your shell is currently in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from issue_flow.init import run_update
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    run_update(repo_root)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/issue_flow/templates/commands/issue-close.md.j2
+++ b/src/issue_flow/templates/commands/issue-close.md.j2
@@ -4,7 +4,15 @@ Run this when implementation is done and you are ready to land the work.
 
 ## Input
 
-Optional: branch name, PR title, or anything special (e.g. draft PR, skip issue doc update, commit all changes).
+Optional text after the command (same line). Examples:
+
+- **No extra text** — close the issue without bumping the package version.
+- **`bump`** or **`patch`** — bump the **patch** semver (e.g. `1.2.0` → `1.2.1`).
+- **`bump minor`** or **`minor`** — bump **minor**.
+- **`bump major`** or **`major`** — bump **major**.
+- **Free text** — if it clearly asks to release or bump the version, infer `patch`, `minor`, or `major` from wording (e.g. “bugfix release” → patch); if unclear, ask once.
+
+Other optional notes still apply: branch name, PR title, draft PR, skip issue doc update, commit all changes, etc.
 
 ## Typical steps
 
@@ -12,23 +20,29 @@ Optional: branch name, PR title, or anything special (e.g. draft PR, skip issue 
    - Run tests and any checks you rely on (e.g. `uv run pytest`).
    - Skim the diff so the commit matches what you intend to ship.
 
-2. **Issue tracking in the repo** (see project rules under `{{ issueflows_dir }}/{{ current_issues_folder }}`)
+2. **Optional version bump** (only if the user asked for it in the command input)
+   - Read `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and follow it.
+   - From the project root, run `uv version --bump patch`, `uv version --bump minor`, or `uv version --bump major` according to the input rules above.
+   - Do this **before** updating issue markdown and **before** commit / push / PR so the new version is in the tree that gets merged.
+   - If the project has no bumpable `pyproject.toml` version, skip and say so; continue with the remaining steps.
+
+3. **Issue tracking in the repo** (see project rules under `{{ issueflows_dir }}/{{ current_issues_folder }}`)
    - Update the status file for this issue: clear checklist, remaining work, and use `- [x] Done` only when fully resolved.
    - If the issue is fully resolved, move its markdown files from `{{ issueflows_dir }}/{{ current_issues_folder }}` to `{{ issueflows_dir }}/{{ solved_folder }}`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}`.
 
-3. **Commit and fix merge conflicts**
-   - Unless told to commit all, stage the right files (avoid unrelated changes).
+4. **Commit and fix merge conflicts**
+   - Unless told to commit all, stage the right files (avoid unrelated changes). Include `pyproject.toml` (and `uv.lock` if it changed) when a version bump ran.
    - Write a commit message that states what changed and why in normal sentences.
    - Make sure you have pulled the last changes from the default branch (e.g. `main`) and check for and fix merge conflicts.
 
-4. **Push**
+5. **Push**
    - Push your branch to `origin` (or the remote you use).
 
-5. **Pull request**
+6. **Pull request**
    - Open a PR against the default branch (e.g. `main`).
    - Describe the change, how to test it, and link the GitHub issue (e.g. `Closes #123` or `Refs #123` in the PR body).
 
-6. **After review**
+7. **After review**
    - Address feedback, push updates, and merge when approved and CI is green.
 
 ## Output

--- a/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
+++ b/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
@@ -6,19 +6,20 @@ This repo uses three Cursor **slash commands** under `{{ cursor_dir }}/commands/
 |--------|------|------|
 | `/issue-init` | `issue-init.md` | Pull an issue from GitHub into the repo as a local markdown file and tidy older current issues. |
 | `/issue-start` | `issue-start.md` | Plan and implement the work described in `{{ issueflows_dir }}/{{ current_issues_folder }}/`. |
-| `/issue-close` | `issue-close.md` | Finish: tests, issue-folder housekeeping, commit, push, PR. |
+| `/issue-close` | `issue-close.md` | Finish: tests, optional semver bump (`uv version --bump …`), issue-folder housekeeping, commit, push, PR. |
 
 ---
 
 ## Agent Skills (optional)
 
-`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ cursor_dir }}/skills/` — longer, on-demand playbooks that mirror the three commands:
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ cursor_dir }}/skills/` — longer, on-demand playbooks that mirror the slash commands (plus a small helper for version bumps):
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
 | `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init` (resolve reference, `gh`, archive, write `*_original.md`). |
 | `issueflow-issue-start` | `/issueflow-issue-start` | Plan + confirmation + scope + implement from `{{ issueflows_dir }}/{{ current_issues_folder }}/`. |
-| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, status checkboxes, move issue docs, commit, push, PR. |
+| `issueflow-issue-close` | `/issueflow-issue-close` | Tests, optional bump, status checkboxes, move issue docs, commit, push, PR. |
+| `issueflow-version-bump` | `@issueflow-version-bump` (often used from `/issue-close`) | Bump `[project]` version in `pyproject.toml` via `uv version --bump patch|minor|major`. |
 
 Each skill sets `disable-model-invocation: true` so it is included when you **explicitly** invoke it, not on every chat. See [Agent Skills](https://cursor.com/docs/context/skills) in the Cursor docs.
 
@@ -62,16 +63,24 @@ Each skill sets `disable-model-invocation: true` so it is included when you **ex
 
 **When:** Implementation is done and you want to ship (commit, push, PR).
 
-**What you pass:** Optional notes (branch name, PR title, draft PR, or "skip issue doc update").
+**What you pass:** Optional notes (branch name, PR title, draft PR, or "skip issue doc update"). You can also ask for a **semver bump** in the same line, for example:
+
+- `/issue-close bump` or `/issue-close patch` — bump **patch** (e.g. `1.2.0` → `1.2.1`) using `uv version --bump patch`.
+- `/issue-close bump minor` — bump **minor**.
+- `/issue-close bump major` or `/issue-close major` — bump **major**.
+- Free text that clearly describes the bump level — the assistant infers patch vs minor vs major.
+
+The bump runs **after** tests and **before** issue-folder moves and **before** commit / push / PR so the PR includes the new version. If `pyproject.toml` has no bumpable version, the assistant skips the bump and continues.
 
 **Typical steps the assistant follows:**
 
 1. **Sanity check** — e.g. `uv run pytest`, review the diff.
-2. **Issue folders** — update status markdown; use `- [x] Done` only when fully resolved. Move completed issue files from `{{ issueflows_dir }}/{{ current_issues_folder }}/` to `{{ issueflows_dir }}/{{ solved_folder }}/`, or partly done work to `{{ issueflows_dir }}/{{ partly_solved_folder }}/` (see project rules).
-3. **Commit** — focused staging and a clear message.
-4. **Push** — to your usual remote (e.g. `origin`).
-5. **Pull request** — open against the default branch; link the GitHub issue (`Closes #n` / `Refs #n`).
-6. **After review** — address comments, merge when ready.
+2. **Optional version bump** — if requested, follow `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump …` from the project root.
+3. **Issue folders** — update status markdown; use `- [x] Done` only when fully resolved. Move completed issue files from `{{ issueflows_dir }}/{{ current_issues_folder }}/` to `{{ issueflows_dir }}/{{ solved_folder }}/`, or partly done work to `{{ issueflows_dir }}/{{ partly_solved_folder }}/` (see project rules).
+4. **Commit** — focused staging and a clear message (include `pyproject.toml` / `uv.lock` if the bump changed them).
+5. **Push** — to your usual remote (e.g. `origin`).
+6. **Pull request** — open against the default branch; link the GitHub issue (`Closes #n` / `Refs #n`).
+7. **After review** — address comments, merge when ready.
 
 **Result:** Short summary of commit, push, and PR link (or what is blocked).
 
@@ -89,7 +98,7 @@ GitHub issue
 Code + tests (+ status updates during work)
     │  /issue-close
     ▼
-Commit → push → PR → merge
+Optional `uv version --bump …` → Commit → push → PR → merge
     │
     └── issue docs in {{ issueflows_dir }}/{{ solved_folder }}/ or {{ issueflows_dir }}/{{ partly_solved_folder }}/ when appropriate
 ```

--- a/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
@@ -1,34 +1,47 @@
 ---
 name: issueflow-issue-close
 description: >-
-  Run the /issue-close workflow: verify tests, update issue status and folder
-  locations, commit, push, and open a PR with a clear summary.
+  Run the /issue-close workflow: verify tests, optional uv semver bump, update
+  issue status and folder locations, commit, push, and open a PR with a clear summary.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue close (`/issue-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, issue-folder updates, git, and PR. Match `{{ cursor_dir }}/commands/issue-close.md`.
+Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR. Match `{{ cursor_dir }}/commands/issue-close.md`.
 
 ## When to use
 
 - The user runs `/issue-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
 
+## Optional version bump (command input)
+
+If the user included text after `/issue-close` that requests a version bump:
+
+- **`bump`** or **`patch`** → `uv version --bump patch`
+- **`bump minor`** or **`minor`** → `uv version --bump minor`
+- **`bump major`** or **`major`** → `uv version --bump major`
+- Otherwise infer **patch** / **minor** / **major** from natural language; ask once if ambiguous.
+
+When a bump applies: read `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+
 ## Instructions
 
 1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes.
 
-2. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ cursor_dir }}/rules/issueflow-rules.mdc` if present.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
-3. **Commit** — Stage intentionally; write a commit message in full sentences describing what changed and why.
+3. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ cursor_dir }}/rules/issueflow-rules.mdc` if present.
 
-4. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
+4. **Commit** — Stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
 
-5. **Push** — Push to the remote the project uses (typically `origin`).
+5. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
 
-6. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+6. **Push** — Push to the remote the project uses (typically `origin`).
 
-7. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+7. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
+
+8. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
 
 ## Constraints
 

--- a/src/issue_flow/templates/skills/issueflow_version_bump/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_version_bump/SKILL.md.j2
@@ -1,0 +1,41 @@
+---
+name: issueflow-version-bump
+description: >-
+  Bump semantic version in pyproject.toml using uv (patch, minor, or major)
+  from the project root.
+disable-model-invocation: true
+---
+
+# issue-flow — version bump
+
+Use when the user wants to **bump the project version** with **uv** before landing work (often invoked from `/issue-close`).
+
+## When to use
+
+- The user asks for a **patch**, **minor**, or **major** semver bump.
+- The repo is a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field (standard for packages using issue-flow).
+
+## Preconditions
+
+1. Run from the **project root** (the directory that contains `pyproject.toml`).
+2. If `pyproject.toml` is missing or has no `[project]` `version`, **skip** the bump, explain why, and continue other work (for example the rest of `/issue-close`) without failing the whole flow.
+
+## Command
+
+Use **only** `uv` with a bump level (`patch`, `minor`, or `major`). Example for a patch release (e.g. `1.2.0` → `1.2.1`):
+
+```bash
+uv version --bump patch
+```
+
+Use `uv version --bump minor` or `uv version --bump major` when that is what the user requested.
+
+## After bumping
+
+1. Confirm the new version in `pyproject.toml` (or from the `uv` command output).
+2. When committing later, stage **`pyproject.toml`**. If **`uv.lock`** changed as well, stage it too; otherwise do not assume it changed.
+
+## Constraints
+
+- Do not substitute `pip` or hand-edit the version unless `uv version` fails and the user agrees to an alternative.
+- Prefer one clear bump level; if the user is ambiguous, ask once rather than guessing **major**.

--- a/src/issue_flow/templating.py
+++ b/src/issue_flow/templating.py
@@ -87,6 +87,10 @@ TEMPLATE_MANIFEST: list[tuple[str, str]] = [
         "skills/issueflow_issue_close/SKILL.md.j2",
         "{cursor_dir}/skills/issueflow-issue-close/SKILL.md",
     ),
+    (
+        "skills/issueflow_version_bump/SKILL.md.j2",
+        "{cursor_dir}/skills/issueflow-version-bump/SKILL.md",
+    ),
 ]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -49,7 +49,12 @@ def test_init_creates_cursor_skills(tmp_path: Path) -> None:
     run_init(tmp_path)
 
     skills = tmp_path / ".cursor" / "skills"
-    for name in ("issueflow-issue-init", "issueflow-issue-start", "issueflow-issue-close"):
+    for name in (
+        "issueflow-issue-init",
+        "issueflow-issue-start",
+        "issueflow-issue-close",
+        "issueflow-version-bump",
+    ):
         skill_file = skills / name / "SKILL.md"
         assert skill_file.is_file(), f"expected {skill_file}"
         text = skill_file.read_text(encoding="utf-8")
@@ -111,6 +116,16 @@ def test_init_templates_reference_issueflows_dir(tmp_path: Path) -> None:
     for filename in ["issue-init.md", "issue-start.md", "issue-close.md"]:
         content = (commands_dir / filename).read_text(encoding="utf-8")
         assert ".issueflows/" in content, f"{filename} should reference .issueflows/"
+
+
+def test_init_issue_close_documents_version_bump(tmp_path: Path) -> None:
+    """issue-close.md should describe optional uv semver bump before commit/PR."""
+    run_init(tmp_path)
+    content = (tmp_path / ".cursor" / "commands" / "issue-close.md").read_text(
+        encoding="utf-8"
+    )
+    assert "uv version --bump" in content
+    assert "issueflow-version-bump" in content
 
 
 def test_init_issue_init_documents_branch_inference(tmp_path: Path) -> None:

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -53,4 +53,4 @@ def test_resolve_output_path() -> None:
 
 
 def test_manifest_entry_count() -> None:
-    assert len(TEMPLATE_MANIFEST) == 8
+    assert len(TEMPLATE_MANIFEST) == 9

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "issue-flow"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Extend packaged `/issue-close` and `issueflow-issue-close` so users can request a semver bump (e.g. `/issue-close bump`) after tests and before commit/PR; document input patterns and workflow.
- Add `issueflow-version-bump` skill (`uv version --bump patch|minor|major`) and register it in `TEMPLATE_MANIFEST`.
- Add `scripts/update_issueflow_setup.py` to refresh this repo's scaffold from templates; document it and lint `scripts/` in CI.
- Bump package version to **0.2.1** (pyproject + uv.lock).
- Archive issue #10 markdown under `.issueflows/03-solved-issues/`.

## Testing

- `uv run pytest`
- `uv run ruff check src/ tests/ scripts/`

Closes #10

Made with [Cursor](https://cursor.com)