### PR TITLE
Init creates or extends .env with ISSUEFLOW_* hints (v0.2.2)

### DIFF
--- a/.issueflows/03-solved-issues/issue16_original.md
+++ b/.issueflows/03-solved-issues/issue16_original.md
@@ -1,0 +1,9 @@
+# Issue #16: can issueflow init command also create a dot env file
+
+Source: https://github.com/jepegit/issue-flow/issues/16
+
+## Original issue text
+
+When running `issueflow init` it creates skills and commands and .issuflows folder with content (and other stuff). However, since it uses python-dotenv, does it also create (or populate if already existing) a .env file?
+
+If not, can that be implemented?

--- a/.issueflows/03-solved-issues/issue16_status.md
+++ b/.issueflows/03-solved-issues/issue16_status.md
@@ -1,0 +1,12 @@
+# Issue #16 — status
+
+- [x] Done
+
+## Summary
+
+`issue-flow init` now creates a project-root `.env` with commented `ISSUEFLOW_*` defaults when the file is missing, or appends commented lines for any variables not yet documented in an existing `.env`. Existing `.env` files are never replaced wholesale, including with `init --force`.
+
+## Changes
+
+- `src/issue_flow/init.py`: `_ensure_dotenv_file`, `_dotenv_documents_key`, wired from `run_init`.
+- `tests/test_init.py`: coverage for create, idempotent skip, append-missing, and force not wiping secrets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-flow"
-version = "0.2.1.post2"
+version = "0.2.2"
 description = "Agents should behave. Let them follow the issue flow."
 readme = "README.md"
 license = "MIT"

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from rich.console import Console
@@ -14,6 +15,64 @@ from issue_flow.templating import (
 )
 
 console = Console()
+
+# Optional project-root `.env` entries (see README). Values are defaults for comments only.
+_DOTENV_KEYS: tuple[tuple[str, str], ...] = (
+    ("ISSUEFLOW_DIR", ".issueflows"),
+    ("ISSUEFLOW_CURSOR_DIR", ".cursor"),
+    ("ISSUEFLOW_DOCS_DIR", "docs"),
+)
+_DOTENV_SECTION_HEADER = "# --- issue-flow: optional environment variables ---\n"
+
+
+def _dotenv_documents_key(content: str, key: str) -> bool:
+    """True if ``key`` appears as an assignment, optionally after ``#`` or ``export``."""
+    pattern = re.compile(
+        rf"(?m)^\s*#?\s*(?:export\s+)?{re.escape(key)}\s*=",
+    )
+    return bool(pattern.search(content))
+
+
+def _ensure_dotenv_file(project_root: Path) -> None:
+    """Create or extend ``.env`` with commented ``ISSUEFLOW_*`` hints.
+
+    Never removes or replaces an existing ``.env`` (including with ``init
+    --force``): only creates a starter file or appends missing keys as
+    comments.
+    """
+    env_path = project_root / ".env"
+    relative = Path(".env")
+
+    if not env_path.exists():
+        lines = [
+            "# issue-flow reads optional ISSUEFLOW_* variables from this file.\n",
+            "# Uncomment to override defaults.\n",
+            "\n",
+        ]
+        for key, default in _DOTENV_KEYS:
+            lines.append(f"# {key}={default}\n")
+        env_path.write_text("".join(lines), encoding="utf-8")
+        console.print(f"  [green]write[/green] {relative}")
+        return
+
+    existing = env_path.read_text(encoding="utf-8")
+    missing = [(k, d) for k, d in _DOTENV_KEYS if not _dotenv_documents_key(existing, k)]
+    if not missing:
+        console.print(
+            f"  [dim]skip[/dim]  {relative}  "
+            "(already lists ISSUEFLOW_* settings; not modified)"
+        )
+        return
+
+    block: list[str] = ["\n", _DOTENV_SECTION_HEADER]
+    for key, default in missing:
+        block.append(f"# {key}={default}\n")
+    with env_path.open("a", encoding="utf-8") as f:
+        f.write("".join(block))
+    console.print(
+        f"  [green]append[/green] {relative}  "
+        f"(added {len(missing)} commented ISSUEFLOW_* line(s))"
+    )
 
 
 def _write_manifest_files(
@@ -69,6 +128,10 @@ def _already_initialized(
 def run_init(project_root: Path, force: bool = False) -> None:
     """Scaffold .issueflows/ directories and .cursor/ config (commands, rules, skills).
 
+    Also ensures a project-root ``.env`` exists or appends commented
+    ``ISSUEFLOW_*`` lines for any keys not yet documented there. Existing
+    ``.env`` files are never replaced in full (even with ``force``).
+
     Re-running without ``force`` skips existing manifest outputs so local
     edits and issue markdown under ``.issueflows/`` are preserved. Manifest
     paths never include issue status or description files.
@@ -98,6 +161,9 @@ def run_init(project_root: Path, force: bool = False) -> None:
     written_files, skipped_files = _write_manifest_files(
         project_root, context, force=force
     )
+
+    console.print()
+    _ensure_dotenv_file(project_root)
 
     console.print()
     if written_files:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,6 +7,55 @@ from pathlib import Path
 from issue_flow.init import run_init
 
 
+def test_init_creates_dotenv_with_commented_keys(tmp_path: Path) -> None:
+    """init should create .env with commented ISSUEFLOW_* defaults when absent."""
+    run_init(tmp_path)
+
+    env_file = tmp_path / ".env"
+    assert env_file.is_file()
+    text = env_file.read_text(encoding="utf-8")
+    assert "# ISSUEFLOW_DIR=.issueflows" in text
+    assert "# ISSUEFLOW_CURSOR_DIR=.cursor" in text
+    assert "# ISSUEFLOW_DOCS_DIR=docs" in text
+
+
+def test_init_second_run_skips_dotenv_when_keys_documented(tmp_path: Path) -> None:
+    """Re-running init should not append duplicate ISSUEFLOW_* hints."""
+    run_init(tmp_path)
+    first = (tmp_path / ".env").read_text(encoding="utf-8")
+
+    run_init(tmp_path)
+    second = (tmp_path / ".env").read_text(encoding="utf-8")
+
+    assert first == second
+
+
+def test_init_appends_missing_dotenv_keys(tmp_path: Path) -> None:
+    """If .env exists without ISSUEFLOW_* lines, init should append commented hints."""
+    (tmp_path / ".env").write_text("OTHER=1\n", encoding="utf-8")
+
+    run_init(tmp_path)
+
+    text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert text.startswith("OTHER=1\n")
+    assert "issue-flow: optional environment" in text
+    assert "# ISSUEFLOW_DIR=.issueflows" in text
+    assert "# ISSUEFLOW_CURSOR_DIR=.cursor" in text
+    assert "# ISSUEFLOW_DOCS_DIR=docs" in text
+
+
+def test_init_force_does_not_wipe_custom_dotenv(tmp_path: Path) -> None:
+    """init --force must not replace an existing .env wholesale."""
+    run_init(tmp_path)
+    env_file = tmp_path / ".env"
+    custom = "MY_SECRET=keep-me\n# ISSUEFLOW_DIR=.issueflows\n# ISSUEFLOW_CURSOR_DIR=.cursor\n# ISSUEFLOW_DOCS_DIR=docs\n"
+    env_file.write_text(custom, encoding="utf-8")
+
+    run_init(tmp_path, force=True)
+
+    assert "MY_SECRET=keep-me" in env_file.read_text(encoding="utf-8")
+
+
 def test_init_creates_directories(tmp_path: Path) -> None:
     """Running init should create .issueflows/ with all four subdirectories."""
     run_init(tmp_path)

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "issue-flow"
-version = "0.2.1.post2"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

`issue-flow init` now ensures a project-root `.env` exists with commented `ISSUEFLOW_*` defaults, or appends commented lines for any keys not yet documented. Existing `.env` files are never replaced wholesale, including with `init --force`.

## Version

Patch bump: **0.2.1.post2 → 0.2.2**.

## How to test

```bash
uv run pytest
```

Manual: run `issue-flow init` in a temp directory with and without a pre-existing `.env`.

Closes #16

Made with [Cursor](https://cursor.com)