### PR TITLE
Rename ISSUEFLOW_CURSOR_DIR to ISSUEFLOW_AGENT_DIR

### DIFF
--- a/.issueflows/03-solved-issues/issue13_original.md
+++ b/.issueflows/03-solved-issues/issue13_original.md
@@ -1,0 +1,7 @@
+# Issue #13: Rename environment variable
+
+Source: https://github.com/jepegit/issue-flow/issues/13
+
+## Original issue text
+
+We have defined the environmental variable `ISSUEFLOW_CURSOR_DIR`. It would be good to rename it to a not-vendor-specific name (anticipating that issue-flow will support other IDEs or similar in the future)

--- a/.issueflows/03-solved-issues/issue13_status.md
+++ b/.issueflows/03-solved-issues/issue13_status.md
@@ -1,0 +1,47 @@
+# Issue #13 status: Rename environment variable
+
+## Status
+
+- [x] Done
+
+## What was done
+
+Renamed the vendor-specific `ISSUEFLOW_CURSOR_DIR` environment variable (and the related internal identifiers) to the IDE-agnostic `ISSUEFLOW_AGENT_DIR`.
+
+### Code / config
+
+- `src/issue_flow/config.py`: `Settings.cursor_dir` -> `Settings.agent_dir`; env lookup switched to `ISSUEFLOW_AGENT_DIR`; `template_context()` now emits the key `"agent_dir"`.
+- `src/issue_flow/init.py`: `_DOTENV_KEYS` entry updated so new or amended `.env` files document `ISSUEFLOW_AGENT_DIR`.
+- `src/issue_flow/templating.py`: every `{cursor_dir}` placeholder in `TEMPLATE_MANIFEST` (and the `resolve_output_path` docstring) is now `{agent_dir}`.
+
+### Jinja templates
+
+Replaced `{{ cursor_dir }}` with `{{ agent_dir }}` in:
+
+- `src/issue_flow/templates/skills/issueflow_issue_init/SKILL.md.j2`
+- `src/issue_flow/templates/skills/issueflow_issue_start/SKILL.md.j2`
+- `src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2`
+- `src/issue_flow/templates/docs/cursor-issue-workflow.md.j2`
+- `src/issue_flow/templates/commands/issue-close.md.j2`
+
+### Docs
+
+- `README.md`: env-var table row renamed and description made IDE-agnostic.
+
+### Tests
+
+- `tests/test_config.py`, `tests/test_init.py`, `tests/test_templating.py`: updated assertions, context keys, and path-template strings to match the new names.
+
+## Verification
+
+- `uv run pytest` -> 30 passed.
+- `rg "cursor_dir|ISSUEFLOW_CURSOR_DIR"` across `src/` and `tests/` -> no matches (only the original issue markdown under `.issueflows/` still mentions the old name, which is expected and gets archived with the issue).
+
+## Behavioural notes / migration
+
+- The default directory value is still `.cursor`; only the env-var and internal identifier names changed.
+- No backwards-compat fallback was added: projects that explicitly set `ISSUEFLOW_CURSOR_DIR` in their `.env` will silently revert to the default `.cursor` until they rename it to `ISSUEFLOW_AGENT_DIR`. Worth calling out in release notes for the next version.
+
+## Remaining work
+
+None.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ issue-flow reads a `.env` file from the project root (via python-dotenv). The fo
 | Variable | Default | Description |
 |---|---|---|
 | `ISSUEFLOW_DIR` | `.issueflows` | Name of the issue-tracking directory. |
-| `ISSUEFLOW_CURSOR_DIR` | `.cursor` | Name of the Cursor config directory. |
+| `ISSUEFLOW_AGENT_DIR` | `.cursor` | Name of the agent/IDE config directory (currently `.cursor`). |
 | `ISSUEFLOW_DOCS_DIR` | `docs` | Where to write the workflow documentation file. |
 
 ## Development

--- a/src/issue_flow/config.py
+++ b/src/issue_flow/config.py
@@ -25,12 +25,16 @@ class Settings:
     issueflows_dir: str = field(
         default_factory=lambda: os.getenv("ISSUEFLOW_DIR", ".issueflows")
     )
-    cursor_dir: str = field(
-        default_factory=lambda: os.getenv("ISSUEFLOW_CURSOR_DIR", ".cursor")
+    agent_dir: str = field(
+        default_factory=lambda: os.getenv("ISSUEFLOW_AGENT_DIR", ".cursor")
     )
     docs_dir: str = field(
         default_factory=lambda: os.getenv("ISSUEFLOW_DOCS_DIR", "docs")
     )
+
+    # Give a deprecation warning if the user is using the old ISSUEFLOW_CURSOR_DIR environment variable
+    if os.getenv("ISSUEFLOW_CURSOR_DIR"):
+        print("WARNING: The ISSUEFLOW_CURSOR_DIR environment variable is deprecated (replaced by ISSUEFLOW_AGENT_DIR).")
 
     # Subdirectory names inside .issueflows/
     tools_folder: str = "00-tools"
@@ -52,7 +56,7 @@ class Settings:
         project_name = _detect_project_name(project_root)
         return {
             "issueflows_dir": self.issueflows_dir,
-            "cursor_dir": self.cursor_dir,
+            "agent_dir": self.agent_dir,
             "docs_dir": self.docs_dir,
             "tools_folder": self.tools_folder,
             "current_issues_folder": self.current_issues_folder,

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -19,7 +19,7 @@ console = Console()
 # Optional project-root `.env` entries (see README). Values are defaults for comments only.
 _DOTENV_KEYS: tuple[tuple[str, str], ...] = (
     ("ISSUEFLOW_DIR", ".issueflows"),
-    ("ISSUEFLOW_CURSOR_DIR", ".cursor"),
+    ("ISSUEFLOW_AGENT_DIR", ".cursor"),
     ("ISSUEFLOW_DOCS_DIR", "docs"),
 )
 _DOTENV_SECTION_HEADER = "# --- issue-flow: optional environment variables ---\n"

--- a/src/issue_flow/templates/commands/issue-close.md.j2
+++ b/src/issue_flow/templates/commands/issue-close.md.j2
@@ -21,7 +21,7 @@ Other optional notes still apply: branch name, PR title, draft PR, skip issue do
    - Skim the diff so the commit matches what you intend to ship.
 
 2. **Optional version bump** (only if the user asked for it in the command input)
-   - Read `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and follow it.
+   - Read `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.md` and follow it.
    - From the project root, run `uv version --bump patch`, `uv version --bump minor`, or `uv version --bump major` according to the input rules above.
    - Do this **before** updating issue markdown and **before** commit / push / PR so the new version is in the tree that gets merged.
    - If the project has no bumpable `pyproject.toml` version, skip and say so; continue with the remaining steps.

--- a/src/issue_flow/templates/commands/issue-start.md.j2
+++ b/src/issue_flow/templates/commands/issue-start.md.j2
@@ -7,7 +7,7 @@ If additional input is added, use that for further detailed guidance
 
 ## Steps
 
-0. If the issue markdown file is not present, or it is ambiguous which one to select, ask.
+0. If the issue markdown file is not present, or it is ambiguous which one to select, ask. Could it be that the user has not run the /issue-init command?
 
 1. Plan. If not in plan mode, stop and ask for a confirmation.
 

--- a/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
+++ b/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
@@ -1,6 +1,6 @@
 # Cursor issue workflow (slash commands)
 
-This repo uses three Cursor **slash commands** under `{{ cursor_dir }}/commands/` that line up with how we track GitHub issues in `{{ issueflows_dir }}/{{ current_issues_folder }}/`. Use them in order when you pick up work from GitHub and want the assistant to follow the same steps.
+This repo uses three Cursor **slash commands** under `{{ agent_dir }}/commands/` that line up with how we track GitHub issues in `{{ issueflows_dir }}/{{ current_issues_folder }}/`. Use them in order when you pick up work from GitHub and want the assistant to follow the same steps.
 
 | Command | File | Role |
 |--------|------|------|
@@ -12,7 +12,7 @@ This repo uses three Cursor **slash commands** under `{{ cursor_dir }}/commands/
 
 ## Agent Skills (optional)
 
-`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ cursor_dir }}/skills/` — longer, on-demand playbooks that mirror the slash commands (plus a small helper for version bumps):
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ agent_dir }}/skills/` — longer, on-demand playbooks that mirror the slash commands (plus a small helper for version bumps):
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
@@ -27,7 +27,7 @@ Each skill sets `disable-model-invocation: true` so it is included when you **ex
 
 ## Agent Skills (optional)
 
-`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ cursor_dir }}/skills/` — longer, on-demand playbooks that mirror the three commands:
+`issue-flow init` / `issue-flow update` also install **Cursor Agent Skills** under `{{ agent_dir }}/skills/` — longer, on-demand playbooks that mirror the three commands:
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
@@ -89,7 +89,7 @@ The bump runs **after** tests and **before** issue-folder moves and **before** c
 **Typical steps the assistant follows:**
 
 1. **Sanity check** — e.g. `uv run pytest`, review the diff.
-2. **Optional version bump** — if requested, follow `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump …` from the project root.
+2. **Optional version bump** — if requested, follow `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump …` from the project root.
 3. **Issue folders** — update status markdown; use `- [x] Done` only when fully resolved. Move completed issue files from `{{ issueflows_dir }}/{{ current_issues_folder }}/` to `{{ issueflows_dir }}/{{ solved_folder }}/`, or partly done work to `{{ issueflows_dir }}/{{ partly_solved_folder }}/` (see project rules).
 4. **Commit** — focused staging and a clear message (include `pyproject.toml` / `uv.lock` if the bump changed them).
 5. **Push** — to your usual remote (e.g. `origin`).
@@ -117,4 +117,4 @@ Optional `uv version --bump …` → Commit → push → PR → merge
     └── issue docs in {{ issueflows_dir }}/{{ solved_folder }}/ or {{ issueflows_dir }}/{{ partly_solved_folder }}/ when appropriate
 ```
 
-The command definitions are the source of truth: `{{ cursor_dir }}/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. The skill packages under `{{ cursor_dir }}/skills/` repeat the same workflows for explicit invocation. This document is a readable overview only.
+The command definitions are the source of truth: `{{ agent_dir }}/commands/issue-init.md`, `issue-start.md`, and `issue-close.md`. The skill packages under `{{ agent_dir }}/skills/` repeat the same workflows for explicit invocation. This document is a readable overview only.

--- a/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 # issue-flow — issue close (`/issue-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR. Match `{{ cursor_dir }}/commands/issue-close.md`.
+Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR. Match `{{ agent_dir }}/commands/issue-close.md`.
 
 ## When to use
 
@@ -23,15 +23,15 @@ If the user included text after `/issue-close` that requests a version bump:
 - **`bump major`** or **`major`** → `uv version --bump major`
 - Otherwise infer **patch** / **minor** / **major** from natural language; ask once if ambiguous.
 
-When a bump applies: read `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+When a bump applies: read `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
 
 ## Instructions
 
 1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. Skim the diff; avoid bundling unrelated changes.
 
-2. **Optional version bump** — If the user asked for a bump (see above), follow `{{ cursor_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
-3. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ cursor_dir }}/rules/issueflow-rules.mdc` if present.
+3. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ agent_dir }}/rules/issueflow-rules.mdc` if present.
 
 4. **Commit** — Stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
 

--- a/src/issue_flow/templates/skills/issueflow_issue_init/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_init/SKILL.md.j2
@@ -9,7 +9,7 @@ disable-model-invocation: true
 
 # issue-flow — issue init (`/issue-init`)
 
-Follow this skill when the user wants to **capture a GitHub issue locally** using the same rules as `{{ cursor_dir }}/commands/issue-init.md`.
+Follow this skill when the user wants to **capture a GitHub issue locally** using the same rules as `{{ agent_dir }}/commands/issue-init.md`.
 
 ## When to use
 

--- a/src/issue_flow/templates/skills/issueflow_issue_start/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_start/SKILL.md.j2
@@ -9,12 +9,12 @@ disable-model-invocation: true
 
 # issue-flow — issue start (`/issue-start`)
 
-Follow this skill when the user wants to **begin implementation** from issue notes, matching `{{ cursor_dir }}/commands/issue-start.md` and project rules.
+Follow this skill when the user wants to **begin implementation** from issue notes, matching `{{ agent_dir }}/commands/issue-start.md` and project rules.
 
 ## When to use
 
 - The user runs `/issue-start`, mentions **issue-start**, or asks to implement from `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
-- Work should follow the issue-flow markdown workflow and stay aligned with `{{ cursor_dir }}/rules/issueflow-rules.mdc` when present.
+- Work should follow the issue-flow markdown workflow and stay aligned with `{{ agent_dir }}/rules/issueflow-rules.mdc` when present.
 
 ## Instructions
 

--- a/src/issue_flow/templating.py
+++ b/src/issue_flow/templating.py
@@ -70,30 +70,30 @@ def render_template(template_name: str, context: dict[str, str]) -> str:
 # Each entry: (template_file, output_path_template)
 # The output_path_template uses simple str.format with the context dict.
 TEMPLATE_MANIFEST: list[tuple[str, str]] = [
-    ("commands/issue-init.md.j2", "{cursor_dir}/commands/issue-init.md"),
-    ("commands/issue-start.md.j2", "{cursor_dir}/commands/issue-start.md"),
-    ("commands/issue-close.md.j2", "{cursor_dir}/commands/issue-close.md"),
-    ("rules/issueflow-rules.mdc.j2", "{cursor_dir}/rules/issueflow-rules.mdc"),
+    ("commands/issue-init.md.j2", "{agent_dir}/commands/issue-init.md"),
+    ("commands/issue-start.md.j2", "{agent_dir}/commands/issue-start.md"),
+    ("commands/issue-close.md.j2", "{agent_dir}/commands/issue-close.md"),
+    ("rules/issueflow-rules.mdc.j2", "{agent_dir}/rules/issueflow-rules.mdc"),
     ("docs/cursor-issue-workflow.md.j2", "{docs_dir}/cursor-issue-workflow.md"),
     (
         "skills/issueflow_issue_init/SKILL.md.j2",
-        "{cursor_dir}/skills/issueflow-issue-init/SKILL.md",
+        "{agent_dir}/skills/issueflow-issue-init/SKILL.md",
     ),
     (
         "skills/issueflow_issue_start/SKILL.md.j2",
-        "{cursor_dir}/skills/issueflow-issue-start/SKILL.md",
+        "{agent_dir}/skills/issueflow-issue-start/SKILL.md",
     ),
     (
         "skills/issueflow_issue_close/SKILL.md.j2",
-        "{cursor_dir}/skills/issueflow-issue-close/SKILL.md",
+        "{agent_dir}/skills/issueflow-issue-close/SKILL.md",
     ),
     (
         "skills/issueflow_version_bump/SKILL.md.j2",
-        "{cursor_dir}/skills/issueflow-version-bump/SKILL.md",
+        "{agent_dir}/skills/issueflow-version-bump/SKILL.md",
     ),
 ]
 
 
 def resolve_output_path(path_template: str, context: dict[str, str]) -> Path:
-    """Resolve a path template like '{cursor_dir}/commands/foo.md' into a Path."""
+    """Resolve a path template like '{agent_dir}/commands/foo.md' into a Path."""
     return Path(path_template.format(**context))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,7 @@ from issue_flow.config import Settings, _detect_project_name
 def test_default_settings() -> None:
     settings = Settings()
     assert settings.issueflows_dir == ".issueflows"
-    assert settings.cursor_dir == ".cursor"
+    assert settings.agent_dir == ".cursor"
     assert settings.docs_dir == "docs"
 
 
@@ -29,7 +29,7 @@ def test_template_context_keys(tmp_path: Path) -> None:
     context = settings.template_context(tmp_path)
     expected_keys = {
         "issueflows_dir",
-        "cursor_dir",
+        "agent_dir",
         "docs_dir",
         "tools_folder",
         "current_issues_folder",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,7 +15,7 @@ def test_init_creates_dotenv_with_commented_keys(tmp_path: Path) -> None:
     assert env_file.is_file()
     text = env_file.read_text(encoding="utf-8")
     assert "# ISSUEFLOW_DIR=.issueflows" in text
-    assert "# ISSUEFLOW_CURSOR_DIR=.cursor" in text
+    assert "# ISSUEFLOW_AGENT_DIR=.cursor" in text
     assert "# ISSUEFLOW_DOCS_DIR=docs" in text
 
 
@@ -40,7 +40,7 @@ def test_init_appends_missing_dotenv_keys(tmp_path: Path) -> None:
     assert text.startswith("OTHER=1\n")
     assert "issue-flow: optional environment" in text
     assert "# ISSUEFLOW_DIR=.issueflows" in text
-    assert "# ISSUEFLOW_CURSOR_DIR=.cursor" in text
+    assert "# ISSUEFLOW_AGENT_DIR=.cursor" in text
     assert "# ISSUEFLOW_DOCS_DIR=docs" in text
 
 
@@ -48,7 +48,7 @@ def test_init_force_does_not_wipe_custom_dotenv(tmp_path: Path) -> None:
     """init --force must not replace an existing .env wholesale."""
     run_init(tmp_path)
     env_file = tmp_path / ".env"
-    custom = "MY_SECRET=keep-me\n# ISSUEFLOW_DIR=.issueflows\n# ISSUEFLOW_CURSOR_DIR=.cursor\n# ISSUEFLOW_DOCS_DIR=docs\n"
+    custom = "MY_SECRET=keep-me\n# ISSUEFLOW_DIR=.issueflows\n# ISSUEFLOW_AGENT_DIR=.cursor\n# ISSUEFLOW_DOCS_DIR=docs\n"
     env_file.write_text(custom, encoding="utf-8")
 
     run_init(tmp_path, force=True)

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -15,7 +15,7 @@ def test_all_templates_render_without_error() -> None:
     """Every template in the manifest should render with default context values."""
     context = {
         "issueflows_dir": ".issueflows",
-        "cursor_dir": ".cursor",
+        "agent_dir": ".cursor",
         "docs_dir": "docs",
         "tools_folder": "00-tools",
         "current_issues_folder": "01-current-issues",
@@ -33,7 +33,7 @@ def test_template_substitution() -> None:
     """Template variables should be replaced in the rendered output."""
     context = {
         "issueflows_dir": "CUSTOM_DIR",
-        "cursor_dir": ".cursor",
+        "agent_dir": ".cursor",
         "docs_dir": "docs",
         "tools_folder": "00-tools",
         "current_issues_folder": "01-current-issues",
@@ -47,8 +47,8 @@ def test_template_substitution() -> None:
 
 
 def test_resolve_output_path() -> None:
-    context = {"cursor_dir": ".cursor", "docs_dir": "docs"}
-    path = resolve_output_path("{cursor_dir}/commands/issue-init.md", context)
+    context = {"agent_dir": ".cursor", "docs_dir": "docs"}
+    path = resolve_output_path("{agent_dir}/commands/issue-init.md", context)
     assert path == Path(".cursor/commands/issue-init.md")
 
 


### PR DESCRIPTION
## Summary

Closes #13.

Rename the vendor-specific environment variable `ISSUEFLOW_CURSOR_DIR` (and the matching internal `cursor_dir` Python field / `{{ cursor_dir }}` Jinja variable) to the IDE-agnostic `ISSUEFLOW_AGENT_DIR` / `agent_dir`, anticipating support for other IDEs/agents.

- Env var: `ISSUEFLOW_CURSOR_DIR` -> `ISSUEFLOW_AGENT_DIR`
- Python field: `Settings.cursor_dir` -> `Settings.agent_dir`
- Jinja/path placeholder: `{{ cursor_dir }}` / `{cursor_dir}` -> `{{ agent_dir }}` / `{agent_dir}`
- Default value stays `.cursor`, so the on-disk layout is unchanged.

## Migration note

Projects that explicitly set `ISSUEFLOW_CURSOR_DIR` in their `.env` will silently fall back to the default `.cursor` until they rename the variable to `ISSUEFLOW_AGENT_DIR`. No deprecation fallback is added in this PR - worth highlighting in the release notes for the next version.

## Test plan

- [x] `uv run pytest` passes (30/30)
- [x] `rg "cursor_dir|ISSUEFLOW_CURSOR_DIR"` returns no matches in `src/` and `tests/`
- [x] Generated commands/skills/docs reference the new variable via `{{ agent_dir }}`


Made with [Cursor](https://cursor.com)