### PR TITLE
Improve /issue-close: flag unrelated changes and remind about issue branch after PR

### DIFF
--- a/.cursor/commands/issue-close.md
+++ b/.cursor/commands/issue-close.md
@@ -31,6 +31,7 @@ Other optional notes still apply: branch name, PR title, draft PR, skip issue do
    - If the issue is fully resolved, move its markdown files from `.issueflows/01-current-issues` to `.issueflows/03-solved-issues`. If partially resolved, move to `.issueflows/02-partly-solved-issues`.
 
 4. **Commit and fix merge conflicts**
+   - Before staging, run `git status` to list all modified/untracked files. If any changes are **not relevant** to this issue, tell the user which ones and ask whether to include them in this commit or leave them for later. Do not silently drop or include unrelated changes.
    - Unless told to commit all, stage the right files (avoid unrelated changes). Include `pyproject.toml` (and `uv.lock` if it changed) when a version bump ran.
    - Write a commit message that states what changed and why in normal sentences.
    - Make sure you have pulled the last changes from the default branch (e.g. `main`) and check for and fix merge conflicts.
@@ -42,7 +43,11 @@ Other optional notes still apply: branch name, PR title, draft PR, skip issue do
    - Open a PR against the default branch (e.g. `main`).
    - Describe the change, how to test it, and link the GitHub issue (e.g. `Closes #123` or `Refs #123` in the PR body).
 
-7. **After review**
+7. **Branch reminder**
+   - After the PR is created, remind the user that the working copy is still on the issue branch, not the default branch (e.g. `main`).
+   - Suggest they run `git switch main` (or the repo's default) before starting any unrelated work, so new changes don't accidentally land on the issue branch.
+
+8. **After review**
    - Address feedback, push updates, and merge when approved and CI is green.
 
 ## Output

--- a/.cursor/commands/issue-start.md
+++ b/.cursor/commands/issue-start.md
@@ -7,7 +7,7 @@ If additional input is added, use that for further detailed guidance
 
 ## Steps
 
-0. If the issue markdown file is not present, or it is ambiguous which one to select, ask.
+0. If the issue markdown file is not present, or it is ambiguous which one to select, ask. Could it be that the user has not run the /issue-init command?
 
 1. Plan. If not in plan mode, stop and ask for a confirmation.
 

--- a/.cursor/skills/issueflow-issue-close/SKILL.md
+++ b/.cursor/skills/issueflow-issue-close/SKILL.md
@@ -33,7 +33,7 @@ When a bump applies: read `.cursor/skills/issueflow-version-bump/SKILL.md`, run 
 
 3. **Issue tracking** — Under `.issueflows/01-current-issues/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `.issueflows/03-solved-issues/`. If partially resolved, move to `.issueflows/02-partly-solved-issues/`. Follow any stricter rules in `.cursor/rules/issueflow-rules.mdc` if present.
 
-4. **Commit** — Stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
+4. **Commit** — First check `git status`; if there are unrelated uncommitted changes, surface them and ask the user whether to include them — do not auto-include or drop silently. Then stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
 
 5. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
 
@@ -41,7 +41,9 @@ When a bump applies: read `.cursor/skills/issueflow-version-bump/SKILL.md`, run 
 
 7. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
 
-8. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+8. **Branch reminder** — After opening the PR, tell the user the working copy is still on the issue branch (not the default branch like `main`). Suggest switching back with `git switch main` before starting unrelated work so new changes don't land on the issue branch.
+
+9. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
 
 ## Constraints
 

--- a/.issueflows/03-solved-issues/issue25_original.md
+++ b/.issueflows/03-solved-issues/issue25_original.md
@@ -1,0 +1,9 @@
+# Issue #25: improve the issue close functionality
+
+Source: https://github.com/jepegit/issue-flow/issues/25
+
+## Original issue text
+
+Enhance `/issue-close` so that it notifies the user if there are uncommitted changes (that issueflow has decided are not relevant for the issue) and asks if they also should be committed.
+
+Also, after creating the PR, notify to the user that they are not on the main branch (so that the user does not accidentally start doing stuff on the issue branch if they not actually want to do that)

--- a/.issueflows/03-solved-issues/issue25_status.md
+++ b/.issueflows/03-solved-issues/issue25_status.md
@@ -1,0 +1,31 @@
+# Issue #25 status — improve the issue close functionality
+
+Source: [issue25_original.md](./issue25_original.md) / https://github.com/jepegit/issue-flow/issues/25
+
+## Goal
+
+Enhance `/issue-close` so that:
+
+1. If there are uncommitted changes that the agent judged **not relevant** to this issue, it surfaces them and asks the user whether to include them in the commit.
+2. After opening the PR, the agent reminds the user that the working copy is still on the issue branch (not the default branch like `main`), so new work doesn't accidentally land on the issue branch.
+
+## Work done
+
+- [x] Updated source command template `src/issue_flow/templates/commands/issue-close.md.j2`:
+  - Added a leading bullet to step 4 that runs `git status` and asks the user about unrelated changes.
+  - Inserted a new step 7 "Branch reminder" and renumbered "After review" to step 8.
+- [x] Mirrored the same edits into the active `.cursor/commands/issue-close.md`.
+- [x] Updated source skill template `src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2`:
+  - Extended step 4 **Commit** with the `git status` / unrelated-changes check.
+  - Inserted new step 8 **Branch reminder** and renumbered **Output** to step 9.
+- [x] Mirrored the same edits into the active `.cursor/skills/issueflow-issue-close/SKILL.md`.
+- [x] Added `test_init_issue_close_documents_uncommitted_and_branch_reminder` in `tests/test_init.py` asserting `git status`, `not relevant`, and `issue branch` appear in the rendered `issue-close.md`.
+- [x] Verified `uv run pytest` passes.
+
+## Remaining work
+
+- None.
+
+## Status
+
+- [x] Done

--- a/src/issue_flow/templates/commands/issue-close.md.j2
+++ b/src/issue_flow/templates/commands/issue-close.md.j2
@@ -31,6 +31,7 @@ Other optional notes still apply: branch name, PR title, draft PR, skip issue do
    - If the issue is fully resolved, move its markdown files from `{{ issueflows_dir }}/{{ current_issues_folder }}` to `{{ issueflows_dir }}/{{ solved_folder }}`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}`.
 
 4. **Commit and fix merge conflicts**
+   - Before staging, run `git status` to list all modified/untracked files. If any changes are **not relevant** to this issue, tell the user which ones and ask whether to include them in this commit or leave them for later. Do not silently drop or include unrelated changes.
    - Unless told to commit all, stage the right files (avoid unrelated changes). Include `pyproject.toml` (and `uv.lock` if it changed) when a version bump ran.
    - Write a commit message that states what changed and why in normal sentences.
    - Make sure you have pulled the last changes from the default branch (e.g. `main`) and check for and fix merge conflicts.
@@ -42,7 +43,11 @@ Other optional notes still apply: branch name, PR title, draft PR, skip issue do
    - Open a PR against the default branch (e.g. `main`).
    - Describe the change, how to test it, and link the GitHub issue (e.g. `Closes #123` or `Refs #123` in the PR body).
 
-7. **After review**
+7. **Branch reminder**
+   - After the PR is created, remind the user that the working copy is still on the issue branch, not the default branch (e.g. `main`).
+   - Suggest they run `git switch main` (or the repo's default) before starting any unrelated work, so new changes don't accidentally land on the issue branch.
+
+8. **After review**
    - Address feedback, push updates, and merge when approved and CI is green.
 
 ## Output

--- a/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2
@@ -33,7 +33,7 @@ When a bump applies: read `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.m
 
 3. **Issue tracking** — Under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, update the status file: remaining work, checklists, and **`- [x] Done`** only when the issue is fully resolved. If fully resolved, move that issue’s markdown files (`issue<n>_*`) to `{{ issueflows_dir }}/{{ solved_folder }}/`. If partially resolved, move to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`. Follow any stricter rules in `{{ agent_dir }}/rules/issueflow-rules.mdc` if present.
 
-4. **Commit** — Stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
+4. **Commit** — First check `git status`; if there are unrelated uncommitted changes, surface them and ask the user whether to include them — do not auto-include or drop silently. Then stage intentionally (include `pyproject.toml` and `uv.lock` if changed after a bump); write a commit message in full sentences describing what changed and why.
 
 5. **Branch hygiene** — Ensure the branch is up to date with the default branch where appropriate; resolve merge conflicts before pushing.
 
@@ -41,7 +41,9 @@ When a bump applies: read `{{ agent_dir }}/skills/issueflow-version-bump/SKILL.m
 
 7. **Pull request** — Open (or update) a PR against the default branch. Body should explain the change, how to test, and link the GitHub issue (`Closes #n` / `Refs #n`).
 
-8. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
+8. **Branch reminder** — After opening the PR, tell the user the working copy is still on the issue branch (not the default branch like `main`). Suggest switching back with `git switch main` before starting unrelated work so new changes don't land on the issue branch.
+
+9. **Output** — Summarize commit, push result, and PR URL, or the next blocker.
 
 ## Constraints
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -177,6 +177,19 @@ def test_init_issue_close_documents_version_bump(tmp_path: Path) -> None:
     assert "issueflow-version-bump" in content
 
 
+def test_init_issue_close_documents_uncommitted_and_branch_reminder(
+    tmp_path: Path,
+) -> None:
+    """issue-close.md should flag unrelated uncommitted changes and warn about the issue branch after PR."""
+    run_init(tmp_path)
+    content = (tmp_path / ".cursor" / "commands" / "issue-close.md").read_text(
+        encoding="utf-8"
+    )
+    assert "git status" in content
+    assert "not relevant" in content
+    assert "issue branch" in content
+
+
 def test_init_issue_init_documents_branch_inference(tmp_path: Path) -> None:
     """issue-init.md should describe resolving an issue from the current branch when no args."""
     run_init(tmp_path)


### PR DESCRIPTION
## Summary

Enhances `/issue-close` so the agent is more careful about scope and branch
hygiene when landing issue work:

- **Unrelated-change prompt (step 4 "Commit")**: before staging, the agent
  runs `git status` and, if any modified/untracked files are not relevant to
  the current issue, surfaces them to the user and asks whether to include
  them in the commit instead of silently dropping or bundling them.
- **Post-PR branch reminder (new step 7)**: after the PR is created, the
  agent reminds the user the working copy is still on the issue branch (not
  the default branch like `main`) and suggests `git switch main` before
  starting any unrelated work, so new changes don't accidentally land on
  the issue branch.

The same guidance is mirrored in the `issueflow-issue-close` skill and in
the rendered `.cursor/` mirrors in this repo so it is immediately active.

Also includes a small unrelated sync of `.cursor/commands/issue-start.md`
to match its source template (step 0 addition about `/issue-init`).

## Files changed

- `src/issue_flow/templates/commands/issue-close.md.j2` (+ rendered mirror)
- `src/issue_flow/templates/skills/issueflow_issue_close/SKILL.md.j2` (+ rendered mirror)
- `.cursor/commands/issue-start.md` (out-of-sync mirror fix)
- `tests/test_init.py` — new `test_init_issue_close_documents_uncommitted_and_branch_reminder` guards `git status`, `not relevant`, `issue branch` in the rendered command.
- `.issueflows/03-solved-issues/issue25_{original,status}.md` — issue tracking moved to solved.

## Test plan

- [x] `uv run pytest` (31 passed)
- [ ] Manually invoke `/issue-close` on a branch with an unrelated local edit and confirm the agent surfaces the unrelated change before staging.
- [ ] After PR creation, confirm the agent reminds the user they are still on the issue branch.

Closes #25

Made with [Cursor](https://cursor.com)