### PR TITLE
Add /issue-pick front-door command (Phase A)

### DIFF
--- a/.cursor/commands/iflow.md
+++ b/.cursor/commands/iflow.md
@@ -2,7 +2,7 @@
 
 `/iflow` inspects the state of the focus issue and **dispatches** to the next logical command in the linear lifecycle — `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never does work those commands don't already do; it just picks the right one for you.
 
-Off-path commands (`/issue-pause`, `/issue-cleanup`, `/issue-yolo`, `/graphify`) are **not** auto-dispatched. Invoke them directly when you need them.
+Off-path commands (`/issue-pick`, `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, `/graphify`) are **not** auto-dispatched. Invoke them directly when you need them. (`/issue-pick` is the front door *before* `/issue-init` — use it when you have not chosen an issue yet.)
 
 Long-lived design docs, design decisions, and project good-practices live under `.issueflows/04-designs-and-guides/`. The downstream commands (`/issue-plan`, `/issue-start`, `/issue-close`) read from and add to that folder as they run; `/iflow` itself does not touch it.
 
@@ -58,7 +58,7 @@ Optional free-form text after the command. `/iflow` forwards the raw trailing te
 ## Constraints
 
 - `/iflow` never skips a downstream command's own prompts. If the downstream step asks a question, surface it normally.
-- `/iflow` never auto-dispatches to `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, or `/graphify`. Those are explicit choices only.
+- `/iflow` never auto-dispatches to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, or `/graphify`. Those are explicit choices only.
 - If the focus issue cannot be resolved (multiple active issues, branch ambiguous), stop and ask. Do not pick one silently.
 - Do not modify files beyond what the downstream command would normally modify. `/iflow` itself writes nothing.
 

--- a/.cursor/commands/issue-pick.md
+++ b/.cursor/commands/issue-pick.md
@@ -1,0 +1,72 @@
+# Pick the next issue to work on (`/issue-pick`)
+
+`/issue-pick` is the **front door** to the issue-flow lifecycle: it helps you **choose** what to work on next, creates the right issue branch, runs `/issue-init` for you, and hands off to the normal flow. Use it when you are on the default branch with nothing in progress and you want help deciding what to pick up.
+
+This is an **off-path** command — the lifecycle dispatcher (`/iflow`) never auto-runs it, because it is interactive and can create GitHub issues and branches. Invoke it explicitly.
+
+## Input
+
+Optional free-form text after the command:
+
+- **No extra text** — survey candidates and ask which to pick.
+- **`fix`** — skip the survey and create a single new "general fixes" GitHub issue (small bug / typo / chore bucket), then work on it. A new issue is created **every time** `fix` is used.
+- **A hint** (e.g. `milestone v0.4`, `something about templating`, `the docs ones`) — used to bias the candidate ranking in Phase 1.
+
+## Phases
+
+`/issue-pick` runs in three phases. Stop and ask whenever a choice is ambiguous; never create a GitHub issue or branch without explicit confirmation.
+
+### Phase 1 — choose the issue
+
+0. **Preflight.** Detect the default branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; fall back to `git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||'`, else `main`). Run `git fetch --prune`. Report the current branch and whether the working tree is clean (`git status --porcelain`).
+
+1. **`fix` shortcut.** If the user passed `fix`, skip candidate selection: go straight to creating a new general-fixes issue (see step 4) and continue to Phase 2.
+
+2. **Source the candidates** (in precedence order):
+   - **Parked work first.** If `.issueflows/02-partly-solved-issues/` contains any `issue<n>_*` groups, list them as the **primary** candidates — these are already-started issues that deserve to be finished before new work begins. Show issue number, title (from each `issue<n>_original.md`), and a one-line status if a status file exists.
+   - **Otherwise, pull from GitHub.** Run `gh issue list --state open --json number,title,labels,milestone,updatedAt` (add `--repo owner/repo` if the default remote is ambiguous). Drop any issue already captured locally under `.issueflows/01-current-issues/`, `02-partly-solved-issues/`, or `03-solved-issues/`.
+
+3. **Rank by relevance and present a shortlist.** Rank candidates using, in combination:
+   - **Milestone** — prefer issues on the nearest / active milestone (and honour any milestone hint in the input).
+   - **Labels** — prefer labels that match recent work or any label hint in the input.
+   - **Topical similarity** — bias toward issues whose title/labels resemble recently solved issues (skim `.issueflows/03-solved-issues/` and recent branch names) so related work clusters together.
+
+   Present a short ranked shortlist (roughly 3–7 entries) as a numbered list with number, title, labels, and milestone, then **ask the user to confirm** the top pick or choose another. Always allow a free-form override (a different issue number, URL, or `fix`). Do not silently pick one.
+
+4. **Create a `fix` issue (only when requested).** When the user passed `fix` (or explicitly asks for a general-fixes bucket): create a **new** GitHub issue with `gh issue create` (e.g. title `chore: general fixes`, body noting it is a catch-all for small fixes/typos/chores). Confirm the title/body with the user first. Record the returned issue number and use it as the chosen issue. A fresh issue is created each time — existing open general-fixes issues are **not** reused.
+
+5. **Over-large issue (note only).** If the chosen issue looks too involved to land in one PR, **mention** that it could be broken into sub-issues and that automated breakdown is planned as a follow-up (Phase B of issue #63). Do **not** auto-create sub-issues in this version — either proceed with the whole issue or let the user pick a smaller one.
+
+### Phase 2 — create the branch
+
+1. **Require a clean tree.** Run `git status --porcelain`. If anything is uncommitted, **stop** and ask the user to commit or stash first. Do not branch on top of unrelated changes.
+
+2. **Branch off the default.** Switch to the default branch and fast-forward if needed, then create the issue branch using GitHub's numeric convention `git switch -c <N>-<short-slug>` (leading issue number, then a short kebab-case slug derived from the title). Confirm the branch name with the user if the slug is non-obvious.
+
+3. **Run `/issue-init` automatically.** The issue number is now known, so follow the `.cursor/commands/issue-init.md` playbook for `<N>` (fetch the issue + comments, write `.issueflows/01-current-issues/issue<N>_original.md`, run its archive sweep). Do not re-implement that logic here — delegate to it.
+
+### Phase 3 — hand off to the standard flow
+
+1. The issue is now captured on a fresh branch. **Ask the user whether to continue with `/issue-plan`** next (the usual next step). Do **not** auto-run it — make the handoff explicit so the user stays in control.
+
+## Constraints
+
+- **Off-path.** Never auto-dispatch `/issue-pick` from `/iflow`, `/issue-start`, or `/issue-close`. The user opts in.
+- **Never create GitHub issues or branches without explicit confirmation.** Show what will be created first.
+- **Respect git safety norms.** Branch off the detected default, never force-push, never delete branches from this command.
+- **Phase B is out of scope** for this version: no automated sub-issue creation, no parking of generated siblings under `02-partly-solved-issues/`. `/issue-pick` only *mentions* the option (tracked as a follow-up to issue #63).
+- Delegate issue capture to `/issue-init` rather than duplicating its fetch/archive logic.
+
+## Output to user
+
+Report:
+- which source the candidate came from (parked work vs GitHub) and the ranked shortlist shown
+- the chosen issue number and title (and, for `fix`, that a new general-fixes issue was created)
+- the branch created (`<N>-<slug>`) and that `/issue-init` ran (file path written)
+- the handoff prompt result (whether the user wants `/issue-plan` next)
+
+## Example invocations
+
+- `/issue-pick` — survey parked + GitHub issues, show a ranked shortlist, confirm, branch, init, hand off.
+- `/issue-pick fix` — create a new `chore: general fixes` issue, branch, init, hand off.
+- `/issue-pick milestone v0.4` — bias the ranking toward the `v0.4` milestone before asking.

--- a/.cursor/rules/issueflow-rules.mdc
+++ b/.cursor/rules/issueflow-rules.mdc
@@ -80,7 +80,9 @@ Use an explicit status checkbox in the status file:
 
 ### Command lifecycle
 
-If you just want the next right step, run **`/iflow`** — it detects state (by file presence under `.issueflows/01-current-issues/` and the status-file `- [x] Done` marker) and dispatches to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never auto-dispatches to `/issue-pause`, `/issue-cleanup`, or `/issue-yolo` — those stay explicit.
+If you have not chosen an issue yet, run **`/issue-pick`** — the front door that helps you select the next issue (parked work first, else ranked open GitHub issues), creates the branch, and runs `/issue-init` for you. It is off-path (never auto-dispatched).
+
+If you just want the next right step, run **`/iflow`** — it detects state (by file presence under `.issueflows/01-current-issues/` and the status-file `- [x] Done` marker) and dispatches to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never auto-dispatches to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo` — those stay explicit.
 
 The full slash-command lifecycle is:
 

--- a/.cursor/skills/issueflow-iflow/SKILL.md
+++ b/.cursor/skills/issueflow-iflow/SKILL.md
@@ -18,7 +18,7 @@ Follow this skill when the user wants to run **the right next step** in the issu
 - The user runs `/iflow`, mentions **iflow**, or asks "what's the next step?" during an issue-flow lifecycle.
 - You want a single entry point that routes to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` based on current state.
 
-Do **not** use this skill for `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`. Those are explicit-only commands.
+Do **not** use this skill for `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`. Those are explicit-only commands. (`/issue-pick` is the front door *before* `/issue-init`, for when no issue has been chosen yet.)
 
 ## Instructions
 
@@ -49,7 +49,7 @@ Do **not** use this skill for `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`
 
 ## Constraints
 
-- Never auto-dispatch to `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`.
+- Never auto-dispatch to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`.
 - If the focus issue cannot be resolved (multiple groups, branch ambiguous), stop and ask.
 - Do not modify files beyond what the downstream command would normally modify. `/iflow` itself writes nothing — all file changes come from the dispatched command.
 - Dispatch to at most one command per `/iflow` invocation.

--- a/.cursor/skills/issueflow-issue-pick/SKILL.md
+++ b/.cursor/skills/issueflow-issue-pick/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: issueflow-issue-pick
+description: >-
+  Run the /issue-pick front door: help the user choose the next issue (parked
+  work in 02-partly-solved-issues/ first, else rank open GitHub issues by
+  milestone, labels, and topical similarity to recently solved work), optionally
+  create a new general-fixes issue on `fix`, create the issue branch, run
+  /issue-init, then hand off to /issue-plan. Off-path: never auto-dispatched by
+  /iflow. Does not auto-create sub-issues.
+disable-model-invocation: true
+---
+
+# issue-flow — pick next issue (`/issue-pick`)
+
+Follow this skill when the user wants help **choosing what to work on next** and getting set up to start. Matches `.cursor/commands/issue-pick.md`.
+
+## When to use
+
+- The user runs `/issue-pick`, mentions "pick the next issue", "what should I work on next?", or "find me an issue".
+- The user is on the default branch with nothing in progress and wants a candidate plus a ready branch.
+
+Do **not** use this skill from `/iflow`, `/issue-start`, or `/issue-close`. `/issue-pick` is explicit-only because it creates GitHub issues and branches.
+
+## Input
+
+- **(nothing)** — survey candidates and ask which to pick.
+- **`fix`** — create a **new** general-fixes GitHub issue (a fresh one every time) and use it.
+- **a hint** (milestone / label / topic) — bias the candidate ranking.
+
+## Instructions
+
+### Phase 1 — choose the issue
+
+1. **Preflight.** Detect the default branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; fall back to `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`). Run `git fetch --prune`. Report current branch + clean/dirty tree (`git status --porcelain`).
+2. **`fix` shortcut.** If the user passed `fix`, skip selection and go to step 5 (create a new general-fixes issue), then Phase 2.
+3. **Source candidates** (precedence):
+   - **Parked work first** — list `issue<n>_*` groups in `.issueflows/02-partly-solved-issues/` as the primary candidates (already-started work to finish first).
+   - **Else GitHub** — `gh issue list --state open --json number,title,labels,milestone,updatedAt` (add `--repo owner/repo` if ambiguous). Drop issues already captured under `01-current-issues/`, `02-partly-solved-issues/`, or `03-solved-issues/`.
+4. **Rank and present.** Rank by **milestone** (nearest/active, honour any hint) + **labels** (match recent work / hint) + **topical similarity** to recently solved issues (skim `.issueflows/03-solved-issues/` and recent branch names). Show a numbered shortlist (~3–7) with number, title, labels, milestone, and **ask the user to confirm** the pick or override. Never pick silently.
+5. **Create a `fix` issue (only when requested).** Use `gh issue create` (e.g. `chore: general fixes`), confirm title/body first, capture the new number. A fresh issue is created each time — never reuse an existing open general-fixes issue.
+6. **Over-large issue (note only).** If the chosen issue is too big for one PR, **mention** that breaking it into sub-issues is possible and tracked as a follow-up (Phase B of issue #63). Do **not** auto-create sub-issues here.
+
+### Phase 2 — create the branch
+
+1. **Require a clean tree** (`git status --porcelain`). If dirty, **stop** and ask the user to commit/stash.
+2. **Branch off the default** — switch to default, fast-forward, then `git switch -c <N>-<short-slug>` (GitHub numeric convention). Confirm a non-obvious slug.
+3. **Run `/issue-init`** for the now-known `<N>` by following `.cursor/commands/issue-init.md` (or the `issueflow-issue-init` skill). Do not duplicate its fetch/archive logic.
+
+### Phase 3 — hand off
+
+1. **Ask** whether to continue with `/issue-plan`. Do not auto-run it.
+
+## Constraints
+
+- Off-path: never auto-dispatch from `/iflow`, `/issue-start`, or `/issue-close`.
+- Never create a GitHub issue or branch without explicit confirmation; show what will be created first.
+- Branch off the detected default; never force-push or delete branches from this skill.
+- **Phase B is out of scope**: no automated sub-issue creation or sibling parking under `02-partly-solved-issues/`. Only mention the option.
+- Delegate issue capture to `/issue-init` rather than re-implementing it.

--- a/.issueflows/03-solved-issues/issue63_original.md
+++ b/.issueflows/03-solved-issues/issue63_original.md
@@ -1,0 +1,23 @@
+# Issue #63: Pick next issue
+
+Source: https://github.com/jepegit/issue-flow/issues/63
+
+## Original issue text
+
+Create a slash command for picking a suitable next issue to work with.
+
+The command operates within several phases
+
+**Phase 1: What issue to work with.**
+
+1. If issues exist in 02-partly-solved-issues, pick from them. If not, we assume issues are stored at github, and we have to pick a relevant issue. Relevance could be based on what milestone they are targetting. Or if they are working with similar topics as the most recent issues worked on. Ask the user if the selected issue is OK. If not OK ask user for input. It would be good if the agent could list some candidates.
+2. If the selected issue seems to be too involved, consider breaking it up into sub-issues. Suggest sub-issues, and create them (also on github). Then start working on the first sub-issue. The other sub-issues should be put in 02-partly-solved-issues.
+3. If the user types "fix", create a single new issue (also on github) and assume that the issue is a general issue for fixing smaller things (like typos, a small bug, or similar).
+
+**Phase 2: Create branch**
+
+1. make sure we are "git clean", i.e. no un-commited changes etc. Then create a branch for the issue (branching from main (or master if main does not exist)) always using naming convention that github uses (starts with a number). Perform the /issue-init step automatically (you already know the issue number).
+
+**Phase 3: Standard issue flow**
+
+1. Continue working on the issue as normal. After issue-init the user will typically continue with /issue-plan. To make it more obvious for the user, ask the user if the user wants to continue with issue-plan.  

--- a/.issueflows/03-solved-issues/issue63_plan.md
+++ b/.issueflows/03-solved-issues/issue63_plan.md
@@ -1,0 +1,133 @@
+# Plan for issue #63: Pick next issue
+
+## Goal
+
+Add a new `/issue-pick` slash command (plus its mirror Agent Skill) that helps the user
+**choose** the next issue to work on, create the right branch, and hand off into the
+existing linear lifecycle. It is the missing "front door" that runs *before* `/issue-init`.
+
+## Confirmed decisions (from user, 2026-06-06)
+
+1. **Name:** `/issue-pick`.
+2. **Scope:** **split** — this PR ships **Phase A** only (pick → clean-tree → branch →
+   auto-`/issue-init` → handoff, incl. the `fix` shortcut). The automated sub-issue
+   breakdown + GitHub sub-issue creation + parking siblings becomes a **follow-up issue
+   (Phase B)** — `/issue-pick` will *mention* the option but not implement it yet.
+3. **Relevance ranking:** milestone **and** labels **and** topical similarity to recently
+   solved issues (`03-solved-issues/`) / recent branches.
+4. **`fix` shortcut:** **create a new** "general fixes" GitHub issue each time (no reuse of
+   an existing open one).
+
+## Constraints
+
+- Commands/skills/docs in this repo are **Jinja2 templates** under `src/issue_flow/templates/`,
+  rendered into `.cursor/` + `docs/` by `issue-flow init`/`update`. Every new command must be added
+  to `TEMPLATE_MANIFEST` in [`src/issue_flow/templating.py`](src/issue_flow/templating.py) or it
+  ships to nobody.
+- Each slash command has a paired skill template (`skills/issueflow_<name>/SKILL.md.j2`) with
+  frontmatter `name:` + `disable-model-invocation: true`. Mirror that convention.
+- The hard manifest-count test (`test_manifest_entry_count`, currently `== 23`) and
+  `test_manifest_has_expected_commands_and_skills` must be updated, or they fail.
+- Templates use `{{ issueflows_dir }}`, `{{ current_issues_folder }}`, `{{ partly_solved_folder }}`,
+  `{{ agent_dir }}` etc. — never hard-code `.issueflows`/`.cursor` in template bodies.
+- Follow existing safety norms: never force-push, never `-D` branches, branch off the detected
+  default (`main`/`master`), one consolidated confirm for multi-step git actions.
+- Respect Cursor command/skill style: numbered Steps, Input, Output, Constraints sections; reuse the
+  branch-preflight pattern from `issue-init`/`issue-plan`.
+- `gh` is the GitHub interface already assumed by `issue-init`/`issue-close`; reuse it
+  (`gh issue list`, `gh issue view`, `gh issue create`).
+
+### Prior art
+
+- `issue-init.md.j2` (`templates/commands/`) — convention: resolves `owner/repo` from `git remote`,
+  uses `gh issue view ... --json`, branch-status preflight, archive sweep of `01-current-issues`.
+  New work: **reuse/delegate** — Phase 2 of `/issue-pick` explicitly *runs the `/issue-init` flow*
+  for the chosen number rather than re-implementing it.
+- `issue-yolo.md.j2` + `skills/issueflow_issue_yolo` — convention: a **chaining** command with
+  up-front preflight (clean tree, default-branch refusal) and a single consolidated confirm, then
+  it follows the other commands' playbooks. New work: **mirror** this structure closely — `/issue-pick`
+  is also a chaining/front-door command (pick → branch → init → handoff).
+- `iflow.md.j2` — convention: an off-path-aware dispatcher that documents which commands are NOT
+  auto-dispatched. New work: **coexist** — add `/issue-pick` to the "off-path / explicit only" lists
+  (it is interactive and creates GitHub issues, so `/iflow` must not auto-run it).
+- `templating.TEMPLATE_MANIFEST` — convention: `(template, "{agent_dir}/.../out")` tuples; skill
+  output dirs use **hyphenated** names (`issueflow-issue-pick`) while template source dirs use
+  **underscores** (`issueflow_issue_pick`). New work: mirror exactly.
+- Docs/rules listing every command (`docs/cursor-issue-workflow.md.j2`, `rules/issueflow-rules.mdc.j2`)
+  — convention: a command table + per-command section + lifecycle prose. New work: extend (migrate the
+  "nine slash commands" wording to ten).
+
+## Approach
+
+Add one new command template + one new skill template, register them, and thread references through
+the docs/rules/iflow so the new command is discoverable and correctly marked off-path. Suggested
+command name: **`/issue-pick`** (alternative: `/issue-next`; see Open questions).
+
+The command body documents three phases (straight from the issue):
+
+**Phase 1 — choose the issue.**
+1. Preflight: detect default branch, `git fetch --prune`, report current branch / clean-or-dirty.
+2. **Source selection (precedence):**
+   - If `{{ partly_solved_folder }}/` contains `issue<n>_*` groups → list them as the primary
+     candidates (these are already-started work) and ask which to resume.
+   - Else pull candidates from GitHub via `gh issue list` (open, not yet captured locally), ranked by
+     **relevance**: same milestone as recent work, and/or topical similarity to the most recently
+     closed/worked issues (infer from `03-solved-issues/` + recent branches). Present a short ranked
+     shortlist with numbers/titles/labels/milestone.
+   - Always **ask the user to confirm** the selected issue; allow free-form override.
+3. **`fix` shortcut:** if the user types `fix`, create **a new** "general fixes" GitHub issue via
+   `gh issue create` (small bug/typo bucket) every time, and use it as the chosen issue.
+4. **Over-large issue (Phase B, deferred):** if the chosen issue looks too involved, the command
+   *notes* that it could be broken into sub-issues and points the user at the Phase B follow-up. The
+   automated `gh issue create` breakdown + parking siblings under `{{ partly_solved_folder }}/` is
+   **out of scope for this PR**.
+
+**Phase 2 — create the branch.**
+1. Refuse / require a clean tree (`git status --porcelain`); guide the user to commit/stash if dirty.
+2. Branch off the detected default using GitHub's numeric convention `git switch -c <N>-<short-slug>`.
+3. Auto-run the `/issue-init` flow for the now-known issue number (delegate to the issue-init
+   playbook; do not duplicate its logic).
+
+**Phase 3 — handoff.**
+1. Land the user in the standard flow and **ask** whether to continue with `/issue-plan` next
+   (don't auto-run it).
+
+The skill mirrors the command (same phases, condensed), with frontmatter
+`name: issueflow-issue-pick` + `disable-model-invocation: true`.
+
+## Files to touch
+
+- `src/issue_flow/templates/commands/issue-pick.md.j2` — **new** command body (3 phases above).
+- `src/issue_flow/templates/skills/issueflow_issue_pick/SKILL.md.j2` — **new** mirror skill.
+- `src/issue_flow/templating.py` — add the command + skill entries to `TEMPLATE_MANIFEST`.
+- `src/issue_flow/templates/docs/cursor-issue-workflow.md.j2` — add `/issue-pick` to the command table,
+  the skills table, a dedicated section, and the end-to-end flow notes; bump "nine slash commands" → ten.
+- `src/issue_flow/templates/rules/issueflow-rules.mdc.j2` — mention `/issue-pick` in the lifecycle prose
+  (front-door before `/issue-init`).
+- `src/issue_flow/templates/commands/iflow.md.j2` + `skills/issueflow_iflow/SKILL.md.j2` — add
+  `/issue-pick` to the "not auto-dispatched / explicit only" lists.
+- `tests/test_templating.py` — bump `test_manifest_entry_count` (23 → 25) and extend
+  `test_manifest_has_expected_commands_and_skills`; add a focused test that the new command documents
+  its three phases and the `fix` shortcut.
+- `tests/test_init.py` — (optional) assert the `/issue-pick` command + skill are scaffolded by `run_init`.
+- `README.md` — (optional) if it enumerates commands, add `/issue-pick`.
+- Regenerate local `.cursor/` copies (run `issue-flow update`/`init`) so this repo dogfoods the command.
+
+## Test strategy
+
+- `uv run pytest` — full suite; specifically the templating + init tests touched above.
+- After editing the manifest, confirm `test_all_templates_render_without_error` still passes (new
+  templates render with the default context, no leftover `{{ ... }}`).
+- Manual: run `issue-flow update .` (or `init`) in a scratch dir and eyeball
+  `.cursor/commands/issue-pick.md` + `.cursor/skills/issueflow-issue-pick/SKILL.md`.
+
+## Open questions
+
+_All resolved — see **Confirmed decisions** above._ `/issue-pick` stays strictly off-path
+(never auto-dispatched by `/iflow`), matching `/issue-yolo`.
+
+## Follow-up (Phase B)
+
+After this PR lands, open a follow-up issue: "automated sub-issue breakdown in `/issue-pick`" —
+propose sub-issues for over-large issues, create them on GitHub (cross-linking the parent), start the
+first, and park siblings under `{{ partly_solved_folder }}/` as lightweight stubs.

--- a/.issueflows/03-solved-issues/issue63_status.md
+++ b/.issueflows/03-solved-issues/issue63_status.md
@@ -1,0 +1,51 @@
+# Status for issue #63: Pick next issue
+
+- [x] Done
+
+(Phase A complete. Phase B — automated sub-issue breakdown — intentionally deferred to a
+separate follow-up issue, per the confirmed plan.)
+
+## Done so far
+
+Shipped the new **`/issue-pick`** front-door slash command (Phase A) plus its mirror Agent Skill,
+and wired it through the whole scaffold:
+
+- **New command template** `src/issue_flow/templates/commands/issue-pick.md.j2` — three phases:
+  1. **Choose** — parked work in `02-partly-solved-issues/` first, else open GitHub issues
+     (`gh issue list`) ranked by milestone + labels + topical similarity to recently solved issues,
+     presented as a confirmable shortlist; `fix` shortcut creates a **new** `chore: general fixes`
+     issue every time.
+  2. **Branch** — clean-tree gate, branch off the default with `git switch -c <N>-<slug>`, then
+     delegate to the `/issue-init` flow.
+  3. **Hand off** — ask whether to continue with `/issue-plan` (never auto-run).
+- **New skill template** `src/issue_flow/templates/skills/issueflow_issue_pick/SKILL.md.j2` —
+  mirrors the command, frontmatter `name: issueflow-issue-pick` + `disable-model-invocation: true`.
+- **Manifest** `src/issue_flow/templating.py` — registered both new templates
+  (24th/25th entries; output dirs use hyphenated skill name).
+- **Off-path wiring** — added `/issue-pick` to the "never auto-dispatched" lists in
+  `commands/iflow.md.j2` and `skills/issueflow_iflow/SKILL.md.j2`.
+- **Docs** `templates/docs/cursor-issue-workflow.md.j2` — bumped "nine → ten" commands, added the
+  command + skill table rows, a dedicated `## 0a. /issue-pick` section, and updated the end-to-end
+  flow diagram.
+- **Rules** `templates/rules/issueflow-rules.mdc.j2` — front-door paragraph in the lifecycle section.
+- **README.md** — command tree, skill tree, off-path list, and the Agent Skills sentence.
+- **Tests** — `tests/test_templating.py` (manifest count 23 → 25, added `issue-pick`/
+  `issueflow_issue_pick` to the expected lists, three new focused tests) and `tests/test_init.py`
+  (new scaffolding assertion).
+- Regenerated the local `.cursor/` scaffold via `uv run issue-flow update .` so this repo dogfoods
+  the new command.
+
+## Verification
+
+- `uv run pytest -q` → **110 passed**.
+- `uv run ruff check src/ tests/` → **All checks passed**.
+
+## Remaining work
+
+- None for this issue. **Phase B** (automated sub-issue suggestion + GitHub creation + parking
+  siblings under `02-partly-solved-issues/`) is tracked as a separate follow-up issue.
+
+## Next step
+
+Run `/issue-close` (optionally with `bump`/`patch`/`minor`/`major`) to land the work, and open the
+Phase B follow-up issue.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,9 @@ than the GitHub release notes they link to.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-06
+
+- **New `/issue-pick` front-door command (#63).** A pre-`/issue-init` command (plus matching `issueflow-issue-pick` skill) that helps choose the next issue: parked work in `02-partly-solved-issues/` first, otherwise open GitHub issues ranked by milestone, labels, and topical similarity to recently solved work; `fix` creates a new "general fixes" issue each time. It then requires a clean tree, creates the `<N>-slug` branch off the default, runs `/issue-init`, and asks before handing off to `/issue-plan`. Off-path — `/iflow` never auto-dispatches to it. Automated sub-issue breakdown of over-large issues is intentionally deferred to a follow-up (Phase B).
 - **Rename `build` → `graphify` (#56).** The graph-rebuild surface is now `/graphify` (slash command), `issueflow-graphify` (skill), and `issue-flow graphify` (CLI subcommand) — the old `build` names are gone. Pure rename, no behavior change; internal helpers keep their "build the graph" names.
 - `/issue-init` now renames the chat/agent tab to reflect the issue topic, on the form "Issue <number> <short description>" (e.g. "Issue 74 cell info"). (#55)
 - **`/issue-plan` prior-art discovery (#57).** New step 1.75 checklist: optional graphify skim of `GRAPH_REPORT.md`, grep for adjacent helpers, record findings under `### Prior art` in plan Constraints (or note none found); strong overlaps become Open questions. `/issue-start` reads that sub-section before new modules; `/issue-yolo` may abbreviate to grep-only for trivial runs. Matching updates to the `issueflow-issue-plan` skill, workflow doc, and templating tests.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ your-project/
     03-solved-issues/        # Completed issues archive
   .cursor/
     commands/
+      issue-pick.md          # /issue-pick — choose the next issue, branch, init (front door)
       iflow.md               # /iflow — smart dispatcher (quick start)
       issue-init.md          # /issue-init — fetch a GitHub issue locally
       issue-plan.md          # /issue-plan — write issue<N>_plan.md and confirm
@@ -27,6 +28,7 @@ your-project/
       issue-yolo.md          # /issue-yolo — all-in-one for small, low-risk issues
       graphify.md            # /graphify — rebuild the graphify knowledge graph (optional)
     skills/                  # Optional Agent Skills (explicit / @ invoke)
+      issueflow-issue-pick/SKILL.md
       issueflow-iflow/SKILL.md
       issueflow-issue-init/SKILL.md
       issueflow-issue-plan/SKILL.md
@@ -54,11 +56,12 @@ The Cursor slash commands give agents a repeatable flow. The linear path is:
 
 Plus a few off-path commands:
 
+- `/issue-pick` — **front door**: when you haven't chosen an issue yet, it helps pick one (parked work in `02-partly-solved-issues/` first, else open GitHub issues ranked by milestone, labels, and similarity to recently solved work), creates the `<N>-slug` branch, and runs `/issue-init`. Pass `fix` to create a new general-fixes issue. Off-path; never auto-dispatched.
 - `/iflow` — **quick start**: inspects the current issue's state and dispatches to the right linear step automatically. A branch-derived number (`42-fix-login` → `N=42`) is authoritative, so `/iflow` works from a fresh branch too.
 - `/issue-pause` — park the current issue in `02-partly-solved-issues/` with a **Remaining work** note; optional WIP commit + switch back to the default branch.
 - `/issue-yolo` — all-in-one chain (`init → plan → start → close`) for small, low-risk issues, with up-front safeguards (refuses on the default branch, refuses with dirty unrelated changes, requires passing tests, single consolidated confirm).
 
-The matching **Agent Skills** (under `.cursor/skills/`) carry the same workflows for on-demand use with `/issueflow-iflow`, `/issueflow-issue-init`, `/issueflow-issue-plan`, `/issueflow-issue-start`, `/issueflow-issue-pause`, `/issueflow-issue-close`, `/issueflow-issue-cleanup`, `/issueflow-issue-yolo`, `@issueflow-version-bump` when you need only the bump steps, or `@issueflow-history-update` when you need only the changelog update (see [Cursor Agent Skills](https://cursor.com/docs/context/skills)).
+The matching **Agent Skills** (under `.cursor/skills/`) carry the same workflows for on-demand use with `/issueflow-issue-pick`, `/issueflow-iflow`, `/issueflow-issue-init`, `/issueflow-issue-plan`, `/issueflow-issue-start`, `/issueflow-issue-pause`, `/issueflow-issue-close`, `/issueflow-issue-cleanup`, `/issueflow-issue-yolo`, `@issueflow-version-bump` when you need only the bump steps, or `@issueflow-history-update` when you need only the changelog update (see [Cursor Agent Skills](https://cursor.com/docs/context/skills)).
 
 ## Prerequisites
 

--- a/docs/cursor-issue-workflow.md
+++ b/docs/cursor-issue-workflow.md
@@ -1,12 +1,13 @@
 # Cursor issue workflow (slash commands)
 
-This repo uses nine Cursor **slash commands** under `.cursor/commands/` that line up with how we track GitHub issues in `.issueflows/01-current-issues/`.
+This repo uses ten Cursor **slash commands** under `.cursor/commands/` that line up with how we track GitHub issues in `.issueflows/01-current-issues/`.
 
-**Quick start: just run `/iflow`.** It inspects the state of the focus issue and dispatches to the right linear-flow command (`/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`) — so you don't have to remember which step is next.
+**Quick start: just run `/iflow`.** It inspects the state of the focus issue and dispatches to the right linear-flow command (`/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`) — so you don't have to remember which step is next. Haven't chosen an issue yet? Start with **`/issue-pick`**.
 
 | Command | File | Role |
 |--------|------|------|
-| `/iflow` | `iflow.md` | **Smart dispatcher.** Detect current state and run `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` automatically. Never auto-dispatches to pause / cleanup / yolo / build. |
+| `/issue-pick` | `issue-pick.md` | **Front door.** Help choose the next issue (parked work first, else ranked open GitHub issues), create the branch, and run `/issue-init`. Off-path; never auto-dispatched. |
+| `/iflow` | `iflow.md` | **Smart dispatcher.** Detect current state and run `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` automatically. Never auto-dispatches to pick / pause / cleanup / yolo / graphify. |
 | `/issue-init` | `issue-init.md` | Pull an issue from GitHub into the repo as a local markdown file and tidy older current issues. |
 | `/issue-plan` | `issue-plan.md` | Write a structured `issue<N>_plan.md` and get explicit user confirmation before any code is touched. |
 | `/issue-start` | `issue-start.md` | Implement the confirmed plan (no planning step of its own any more). |
@@ -24,6 +25,7 @@ This repo uses nine Cursor **slash commands** under `.cursor/commands/` that lin
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
+| `issueflow-issue-pick` | `/issueflow-issue-pick` | Front door — same flow as `/issue-pick` (choose issue, branch, init, hand off). |
 | `issueflow-iflow` | `/issueflow-iflow` or attach `@issueflow-iflow` | Smart dispatcher — same state machine as `/iflow`. |
 | `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init`. |
 | `issueflow-issue-plan` | `/issueflow-issue-plan` | Same flow as `/issue-plan` (write & confirm plan). |
@@ -48,6 +50,26 @@ Two recurring pain points the commands actively help with:
 - **Left-overs in `.issueflows/01-current-issues/`.** Both `/issue-init` (when a new issue is captured) and `/issue-start` (before implementation begins) sweep that folder: every `issue<n>_*` group **other than the focus issue** is moved automatically to `.issueflows/03-solved-issues/` if a status file contains `- [x] Done`, otherwise to `.issueflows/02-partly-solved-issues/`.
 
 All the commands that touch git also run a short **branch-status preflight**: `git fetch --prune`, current branch, ahead/behind vs the default branch, and a warning when the current branch's leading digits refer to an issue already archived in `02-`/`03-`.
+
+---
+
+## 0a. `/issue-pick` — choose the next issue (front door)
+
+**When:** You are on the default branch with nothing in progress and want help deciding what to work on next.
+
+**What you pass:** Nothing (survey + ask), `fix` (create a new general-fixes issue every time), or a hint (`milestone v0.4`, a topic) to bias ranking.
+
+**What the assistant does (three phases):**
+
+1. **Choose.** Prefers parked work in `.issueflows/02-partly-solved-issues/`; otherwise lists open GitHub issues (`gh issue list`) ranked by **milestone**, **labels**, and **topical similarity** to recently solved issues, then asks you to confirm a pick from a short shortlist. `fix` skips the survey and creates a new `chore: general fixes` issue.
+2. **Branch.** Requires a clean tree, branches off the default with the GitHub numeric convention `git switch -c <N>-<short-slug>`, then runs the `/issue-init` flow automatically for `<N>`.
+3. **Hand off.** Asks whether to continue with `/issue-plan` (never auto-runs it).
+
+**Out of scope (Phase B follow-up):** automated breakdown of an over-large issue into sub-issues created on GitHub and parked under `02-partly-solved-issues/`. `/issue-pick` only *mentions* the option for now.
+
+**Off-path:** `/iflow` never auto-dispatches to `/issue-pick`; it creates GitHub issues and branches, so you opt in explicitly.
+
+**Result:** A chosen issue captured on a fresh `<N>-<slug>` branch, ready for `/issue-plan`.
 
 ---
 
@@ -238,6 +260,9 @@ The bump runs **after** tests and **before** issue-folder moves and **before** c
 Tip: at any point in the linear flow below, you can just run `/iflow` and it will dispatch to the right step based on current state.
 
 ```text
+(no issue chosen yet)
+    │  /issue-pick   → choose issue, create branch, run /issue-init
+    ▼
 GitHub issue
     │  /issue-init   (or /iflow)
     ▼
@@ -258,6 +283,7 @@ Commit → push → PR
 Default branch, stale local branches deleted (with single confirm)
 
 Detours:
+  /issue-pick   — front door: choose the next issue, branch, init (before the linear flow)
   /issue-pause  — park mid-stream; moves issueN_* to 02-partly-solved-issues/
   /issue-yolo   — chain init → plan → start → close for tiny fixes (safeguarded)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "issue-flow"
-version = "0.3.1"
+version = "0.3.2"
 description = "Agents should behave. Let them follow the issue flow."
 readme = "README.md"
 license = "MIT"

--- a/src/issue_flow/templates/commands/iflow.md.j2
+++ b/src/issue_flow/templates/commands/iflow.md.j2
@@ -2,7 +2,7 @@
 
 `/iflow` inspects the state of the focus issue and **dispatches** to the next logical command in the linear lifecycle — `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never does work those commands don't already do; it just picks the right one for you.
 
-Off-path commands (`/issue-pause`, `/issue-cleanup`, `/issue-yolo`, `/graphify`) are **not** auto-dispatched. Invoke them directly when you need them.
+Off-path commands (`/issue-pick`, `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, `/graphify`) are **not** auto-dispatched. Invoke them directly when you need them. (`/issue-pick` is the front door *before* `/issue-init` — use it when you have not chosen an issue yet.)
 
 Long-lived design docs, design decisions, and project good-practices live under `{{ issueflows_dir }}/{{ designs_folder }}/`. The downstream commands (`/issue-plan`, `/issue-start`, `/issue-close`) read from and add to that folder as they run; `/iflow` itself does not touch it.
 
@@ -58,7 +58,7 @@ Optional free-form text after the command. `/iflow` forwards the raw trailing te
 ## Constraints
 
 - `/iflow` never skips a downstream command's own prompts. If the downstream step asks a question, surface it normally.
-- `/iflow` never auto-dispatches to `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, or `/graphify`. Those are explicit choices only.
+- `/iflow` never auto-dispatches to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, `/issue-yolo`, or `/graphify`. Those are explicit choices only.
 - If the focus issue cannot be resolved (multiple active issues, branch ambiguous), stop and ask. Do not pick one silently.
 - Do not modify files beyond what the downstream command would normally modify. `/iflow` itself writes nothing.
 

--- a/src/issue_flow/templates/commands/issue-pick.md.j2
+++ b/src/issue_flow/templates/commands/issue-pick.md.j2
@@ -1,0 +1,72 @@
+# Pick the next issue to work on (`/issue-pick`)
+
+`/issue-pick` is the **front door** to the issue-flow lifecycle: it helps you **choose** what to work on next, creates the right issue branch, runs `/issue-init` for you, and hands off to the normal flow. Use it when you are on the default branch with nothing in progress and you want help deciding what to pick up.
+
+This is an **off-path** command — the lifecycle dispatcher (`/iflow`) never auto-runs it, because it is interactive and can create GitHub issues and branches. Invoke it explicitly.
+
+## Input
+
+Optional free-form text after the command:
+
+- **No extra text** — survey candidates and ask which to pick.
+- **`fix`** — skip the survey and create a single new "general fixes" GitHub issue (small bug / typo / chore bucket), then work on it. A new issue is created **every time** `fix` is used.
+- **A hint** (e.g. `milestone v0.4`, `something about templating`, `the docs ones`) — used to bias the candidate ranking in Phase 1.
+
+## Phases
+
+`/issue-pick` runs in three phases. Stop and ask whenever a choice is ambiguous; never create a GitHub issue or branch without explicit confirmation.
+
+### Phase 1 — choose the issue
+
+0. **Preflight.** Detect the default branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; fall back to `git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's|^origin/||'`, else `main`). Run `git fetch --prune`. Report the current branch and whether the working tree is clean (`git status --porcelain`).
+
+1. **`fix` shortcut.** If the user passed `fix`, skip candidate selection: go straight to creating a new general-fixes issue (see step 4) and continue to Phase 2.
+
+2. **Source the candidates** (in precedence order):
+   - **Parked work first.** If `{{ issueflows_dir }}/{{ partly_solved_folder }}/` contains any `issue<n>_*` groups, list them as the **primary** candidates — these are already-started issues that deserve to be finished before new work begins. Show issue number, title (from each `issue<n>_original.md`), and a one-line status if a status file exists.
+   - **Otherwise, pull from GitHub.** Run `gh issue list --state open --json number,title,labels,milestone,updatedAt` (add `--repo owner/repo` if the default remote is ambiguous). Drop any issue already captured locally under `{{ issueflows_dir }}/{{ current_issues_folder }}/`, `{{ partly_solved_folder }}/`, or `{{ solved_folder }}/`.
+
+3. **Rank by relevance and present a shortlist.** Rank candidates using, in combination:
+   - **Milestone** — prefer issues on the nearest / active milestone (and honour any milestone hint in the input).
+   - **Labels** — prefer labels that match recent work or any label hint in the input.
+   - **Topical similarity** — bias toward issues whose title/labels resemble recently solved issues (skim `{{ issueflows_dir }}/{{ solved_folder }}/` and recent branch names) so related work clusters together.
+
+   Present a short ranked shortlist (roughly 3–7 entries) as a numbered list with number, title, labels, and milestone, then **ask the user to confirm** the top pick or choose another. Always allow a free-form override (a different issue number, URL, or `fix`). Do not silently pick one.
+
+4. **Create a `fix` issue (only when requested).** When the user passed `fix` (or explicitly asks for a general-fixes bucket): create a **new** GitHub issue with `gh issue create` (e.g. title `chore: general fixes`, body noting it is a catch-all for small fixes/typos/chores). Confirm the title/body with the user first. Record the returned issue number and use it as the chosen issue. A fresh issue is created each time — existing open general-fixes issues are **not** reused.
+
+5. **Over-large issue (note only).** If the chosen issue looks too involved to land in one PR, **mention** that it could be broken into sub-issues and that automated breakdown is planned as a follow-up (Phase B of issue #63). Do **not** auto-create sub-issues in this version — either proceed with the whole issue or let the user pick a smaller one.
+
+### Phase 2 — create the branch
+
+1. **Require a clean tree.** Run `git status --porcelain`. If anything is uncommitted, **stop** and ask the user to commit or stash first. Do not branch on top of unrelated changes.
+
+2. **Branch off the default.** Switch to the default branch and fast-forward if needed, then create the issue branch using GitHub's numeric convention `git switch -c <N>-<short-slug>` (leading issue number, then a short kebab-case slug derived from the title). Confirm the branch name with the user if the slug is non-obvious.
+
+3. **Run `/issue-init` automatically.** The issue number is now known, so follow the `{{ agent_dir }}/commands/issue-init.md` playbook for `<N>` (fetch the issue + comments, write `{{ issueflows_dir }}/{{ current_issues_folder }}/issue<N>_original.md`, run its archive sweep). Do not re-implement that logic here — delegate to it.
+
+### Phase 3 — hand off to the standard flow
+
+1. The issue is now captured on a fresh branch. **Ask the user whether to continue with `/issue-plan`** next (the usual next step). Do **not** auto-run it — make the handoff explicit so the user stays in control.
+
+## Constraints
+
+- **Off-path.** Never auto-dispatch `/issue-pick` from `/iflow`, `/issue-start`, or `/issue-close`. The user opts in.
+- **Never create GitHub issues or branches without explicit confirmation.** Show what will be created first.
+- **Respect git safety norms.** Branch off the detected default, never force-push, never delete branches from this command.
+- **Phase B is out of scope** for this version: no automated sub-issue creation, no parking of generated siblings under `{{ partly_solved_folder }}/`. `/issue-pick` only *mentions* the option (tracked as a follow-up to issue #63).
+- Delegate issue capture to `/issue-init` rather than duplicating its fetch/archive logic.
+
+## Output to user
+
+Report:
+- which source the candidate came from (parked work vs GitHub) and the ranked shortlist shown
+- the chosen issue number and title (and, for `fix`, that a new general-fixes issue was created)
+- the branch created (`<N>-<slug>`) and that `/issue-init` ran (file path written)
+- the handoff prompt result (whether the user wants `/issue-plan` next)
+
+## Example invocations
+
+- `/issue-pick` — survey parked + GitHub issues, show a ranked shortlist, confirm, branch, init, hand off.
+- `/issue-pick fix` — create a new `chore: general fixes` issue, branch, init, hand off.
+- `/issue-pick milestone v0.4` — bias the ranking toward the `v0.4` milestone before asking.

--- a/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
+++ b/src/issue_flow/templates/docs/cursor-issue-workflow.md.j2
@@ -1,12 +1,13 @@
 # Cursor issue workflow (slash commands)
 
-This repo uses nine Cursor **slash commands** under `{{ agent_dir }}/commands/` that line up with how we track GitHub issues in `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
+This repo uses ten Cursor **slash commands** under `{{ agent_dir }}/commands/` that line up with how we track GitHub issues in `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
 
-**Quick start: just run `/iflow`.** It inspects the state of the focus issue and dispatches to the right linear-flow command (`/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`) — so you don't have to remember which step is next.
+**Quick start: just run `/iflow`.** It inspects the state of the focus issue and dispatches to the right linear-flow command (`/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`) — so you don't have to remember which step is next. Haven't chosen an issue yet? Start with **`/issue-pick`**.
 
 | Command | File | Role |
 |--------|------|------|
-| `/iflow` | `iflow.md` | **Smart dispatcher.** Detect current state and run `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` automatically. Never auto-dispatches to pause / cleanup / yolo / build. |
+| `/issue-pick` | `issue-pick.md` | **Front door.** Help choose the next issue (parked work first, else ranked open GitHub issues), create the branch, and run `/issue-init`. Off-path; never auto-dispatched. |
+| `/iflow` | `iflow.md` | **Smart dispatcher.** Detect current state and run `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` automatically. Never auto-dispatches to pick / pause / cleanup / yolo / graphify. |
 | `/issue-init` | `issue-init.md` | Pull an issue from GitHub into the repo as a local markdown file and tidy older current issues. |
 | `/issue-plan` | `issue-plan.md` | Write a structured `issue<N>_plan.md` and get explicit user confirmation before any code is touched. |
 | `/issue-start` | `issue-start.md` | Implement the confirmed plan (no planning step of its own any more). |
@@ -24,6 +25,7 @@ This repo uses nine Cursor **slash commands** under `{{ agent_dir }}/commands/` 
 
 | Skill folder | Invoke (examples) | Role |
 |--------------|-------------------|------|
+| `issueflow-issue-pick` | `/issueflow-issue-pick` | Front door — same flow as `/issue-pick` (choose issue, branch, init, hand off). |
 | `issueflow-iflow` | `/issueflow-iflow` or attach `@issueflow-iflow` | Smart dispatcher — same state machine as `/iflow`. |
 | `issueflow-issue-init` | `/issueflow-issue-init` or attach `@issueflow-issue-init` | Same flow as `/issue-init`. |
 | `issueflow-issue-plan` | `/issueflow-issue-plan` | Same flow as `/issue-plan` (write & confirm plan). |
@@ -48,6 +50,26 @@ Two recurring pain points the commands actively help with:
 - **Left-overs in `{{ issueflows_dir }}/{{ current_issues_folder }}/`.** Both `/issue-init` (when a new issue is captured) and `/issue-start` (before implementation begins) sweep that folder: every `issue<n>_*` group **other than the focus issue** is moved automatically to `{{ issueflows_dir }}/{{ solved_folder }}/` if a status file contains `- [x] Done`, otherwise to `{{ issueflows_dir }}/{{ partly_solved_folder }}/`.
 
 All the commands that touch git also run a short **branch-status preflight**: `git fetch --prune`, current branch, ahead/behind vs the default branch, and a warning when the current branch's leading digits refer to an issue already archived in `02-`/`03-`.
+
+---
+
+## 0a. `/issue-pick` — choose the next issue (front door)
+
+**When:** You are on the default branch with nothing in progress and want help deciding what to work on next.
+
+**What you pass:** Nothing (survey + ask), `fix` (create a new general-fixes issue every time), or a hint (`milestone v0.4`, a topic) to bias ranking.
+
+**What the assistant does (three phases):**
+
+1. **Choose.** Prefers parked work in `{{ issueflows_dir }}/{{ partly_solved_folder }}/`; otherwise lists open GitHub issues (`gh issue list`) ranked by **milestone**, **labels**, and **topical similarity** to recently solved issues, then asks you to confirm a pick from a short shortlist. `fix` skips the survey and creates a new `chore: general fixes` issue.
+2. **Branch.** Requires a clean tree, branches off the default with the GitHub numeric convention `git switch -c <N>-<short-slug>`, then runs the `/issue-init` flow automatically for `<N>`.
+3. **Hand off.** Asks whether to continue with `/issue-plan` (never auto-runs it).
+
+**Out of scope (Phase B follow-up):** automated breakdown of an over-large issue into sub-issues created on GitHub and parked under `{{ partly_solved_folder }}/`. `/issue-pick` only *mentions* the option for now.
+
+**Off-path:** `/iflow` never auto-dispatches to `/issue-pick`; it creates GitHub issues and branches, so you opt in explicitly.
+
+**Result:** A chosen issue captured on a fresh `<N>-<slug>` branch, ready for `/issue-plan`.
 
 ---
 
@@ -238,6 +260,9 @@ The bump runs **after** tests and **before** issue-folder moves and **before** c
 Tip: at any point in the linear flow below, you can just run `/iflow` and it will dispatch to the right step based on current state.
 
 ```text
+(no issue chosen yet)
+    │  /issue-pick   → choose issue, create branch, run /issue-init
+    ▼
 GitHub issue
     │  /issue-init   (or /iflow)
     ▼
@@ -258,6 +283,7 @@ Commit → push → PR
 Default branch, stale local branches deleted (with single confirm)
 
 Detours:
+  /issue-pick   — front door: choose the next issue, branch, init (before the linear flow)
   /issue-pause  — park mid-stream; moves issueN_* to {{ partly_solved_folder }}/
   /issue-yolo   — chain init → plan → start → close for tiny fixes (safeguarded)
 ```

--- a/src/issue_flow/templates/rules/issueflow-rules.mdc.j2
+++ b/src/issue_flow/templates/rules/issueflow-rules.mdc.j2
@@ -80,7 +80,9 @@ Use an explicit status checkbox in the status file:
 
 ### Command lifecycle
 
-If you just want the next right step, run **`/iflow`** — it detects state (by file presence under `{{ issueflows_dir }}/{{ current_issues_folder }}/` and the status-file `- [x] Done` marker) and dispatches to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never auto-dispatches to `/issue-pause`, `/issue-cleanup`, or `/issue-yolo` — those stay explicit.
+If you have not chosen an issue yet, run **`/issue-pick`** — the front door that helps you select the next issue (parked work first, else ranked open GitHub issues), creates the branch, and runs `/issue-init` for you. It is off-path (never auto-dispatched).
+
+If you just want the next right step, run **`/iflow`** — it detects state (by file presence under `{{ issueflows_dir }}/{{ current_issues_folder }}/` and the status-file `- [x] Done` marker) and dispatches to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close`. It never auto-dispatches to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo` — those stay explicit.
 
 The full slash-command lifecycle is:
 

--- a/src/issue_flow/templates/skills/issueflow_iflow/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_iflow/SKILL.md.j2
@@ -18,7 +18,7 @@ Follow this skill when the user wants to run **the right next step** in the issu
 - The user runs `/iflow`, mentions **iflow**, or asks "what's the next step?" during an issue-flow lifecycle.
 - You want a single entry point that routes to `/issue-init`, `/issue-plan`, `/issue-start`, or `/issue-close` based on current state.
 
-Do **not** use this skill for `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`. Those are explicit-only commands.
+Do **not** use this skill for `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`. Those are explicit-only commands. (`/issue-pick` is the front door *before* `/issue-init`, for when no issue has been chosen yet.)
 
 ## Instructions
 
@@ -49,7 +49,7 @@ Do **not** use this skill for `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`
 
 ## Constraints
 
-- Never auto-dispatch to `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`.
+- Never auto-dispatch to `/issue-pick`, `/issue-pause`, `/issue-cleanup`, or `/issue-yolo`.
 - If the focus issue cannot be resolved (multiple groups, branch ambiguous), stop and ask.
 - Do not modify files beyond what the downstream command would normally modify. `/iflow` itself writes nothing — all file changes come from the dispatched command.
 - Dispatch to at most one command per `/iflow` invocation.

--- a/src/issue_flow/templates/skills/issueflow_issue_pick/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/issueflow_issue_pick/SKILL.md.j2
@@ -1,0 +1,59 @@
+---
+name: issueflow-issue-pick
+description: >-
+  Run the /issue-pick front door: help the user choose the next issue (parked
+  work in {{ partly_solved_folder }}/ first, else rank open GitHub issues by
+  milestone, labels, and topical similarity to recently solved work), optionally
+  create a new general-fixes issue on `fix`, create the issue branch, run
+  /issue-init, then hand off to /issue-plan. Off-path: never auto-dispatched by
+  /iflow. Does not auto-create sub-issues.
+disable-model-invocation: true
+---
+
+# issue-flow — pick next issue (`/issue-pick`)
+
+Follow this skill when the user wants help **choosing what to work on next** and getting set up to start. Matches `{{ agent_dir }}/commands/issue-pick.md`.
+
+## When to use
+
+- The user runs `/issue-pick`, mentions "pick the next issue", "what should I work on next?", or "find me an issue".
+- The user is on the default branch with nothing in progress and wants a candidate plus a ready branch.
+
+Do **not** use this skill from `/iflow`, `/issue-start`, or `/issue-close`. `/issue-pick` is explicit-only because it creates GitHub issues and branches.
+
+## Input
+
+- **(nothing)** — survey candidates and ask which to pick.
+- **`fix`** — create a **new** general-fixes GitHub issue (a fresh one every time) and use it.
+- **a hint** (milestone / label / topic) — bias the candidate ranking.
+
+## Instructions
+
+### Phase 1 — choose the issue
+
+1. **Preflight.** Detect the default branch (`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; fall back to `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`). Run `git fetch --prune`. Report current branch + clean/dirty tree (`git status --porcelain`).
+2. **`fix` shortcut.** If the user passed `fix`, skip selection and go to step 5 (create a new general-fixes issue), then Phase 2.
+3. **Source candidates** (precedence):
+   - **Parked work first** — list `issue<n>_*` groups in `{{ issueflows_dir }}/{{ partly_solved_folder }}/` as the primary candidates (already-started work to finish first).
+   - **Else GitHub** — `gh issue list --state open --json number,title,labels,milestone,updatedAt` (add `--repo owner/repo` if ambiguous). Drop issues already captured under `{{ current_issues_folder }}/`, `{{ partly_solved_folder }}/`, or `{{ solved_folder }}/`.
+4. **Rank and present.** Rank by **milestone** (nearest/active, honour any hint) + **labels** (match recent work / hint) + **topical similarity** to recently solved issues (skim `{{ issueflows_dir }}/{{ solved_folder }}/` and recent branch names). Show a numbered shortlist (~3–7) with number, title, labels, milestone, and **ask the user to confirm** the pick or override. Never pick silently.
+5. **Create a `fix` issue (only when requested).** Use `gh issue create` (e.g. `chore: general fixes`), confirm title/body first, capture the new number. A fresh issue is created each time — never reuse an existing open general-fixes issue.
+6. **Over-large issue (note only).** If the chosen issue is too big for one PR, **mention** that breaking it into sub-issues is possible and tracked as a follow-up (Phase B of issue #63). Do **not** auto-create sub-issues here.
+
+### Phase 2 — create the branch
+
+1. **Require a clean tree** (`git status --porcelain`). If dirty, **stop** and ask the user to commit/stash.
+2. **Branch off the default** — switch to default, fast-forward, then `git switch -c <N>-<short-slug>` (GitHub numeric convention). Confirm a non-obvious slug.
+3. **Run `/issue-init`** for the now-known `<N>` by following `{{ agent_dir }}/commands/issue-init.md` (or the `issueflow-issue-init` skill). Do not duplicate its fetch/archive logic.
+
+### Phase 3 — hand off
+
+1. **Ask** whether to continue with `/issue-plan`. Do not auto-run it.
+
+## Constraints
+
+- Off-path: never auto-dispatch from `/iflow`, `/issue-start`, or `/issue-close`.
+- Never create a GitHub issue or branch without explicit confirmation; show what will be created first.
+- Branch off the detected default; never force-push or delete branches from this skill.
+- **Phase B is out of scope**: no automated sub-issue creation or sibling parking under `{{ partly_solved_folder }}/`. Only mention the option.
+- Delegate issue capture to `/issue-init` rather than re-implementing it.

--- a/src/issue_flow/templating.py
+++ b/src/issue_flow/templating.py
@@ -71,6 +71,7 @@ def render_template(template_name: str, context: dict[str, str]) -> str:
 # The output_path_template uses simple str.format with the context dict.
 TEMPLATE_MANIFEST: list[tuple[str, str]] = [
     ("commands/iflow.md.j2", "{agent_dir}/commands/iflow.md"),
+    ("commands/issue-pick.md.j2", "{agent_dir}/commands/issue-pick.md"),
     ("commands/issue-init.md.j2", "{agent_dir}/commands/issue-init.md"),
     ("commands/issue-plan.md.j2", "{agent_dir}/commands/issue-plan.md"),
     ("commands/issue-start.md.j2", "{agent_dir}/commands/issue-start.md"),
@@ -84,6 +85,10 @@ TEMPLATE_MANIFEST: list[tuple[str, str]] = [
     (
         "skills/issueflow_iflow/SKILL.md.j2",
         "{agent_dir}/skills/issueflow-iflow/SKILL.md",
+    ),
+    (
+        "skills/issueflow_issue_pick/SKILL.md.j2",
+        "{agent_dir}/skills/issueflow-issue-pick/SKILL.md",
     ),
     (
         "skills/issueflow_issue_init/SKILL.md.j2",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -386,6 +386,27 @@ def test_init_creates_graphify_command_and_skill(tmp_path: Path) -> None:
     assert "disable-model-invocation: true" in skill_content
 
 
+def test_init_creates_issue_pick_command_and_skill(tmp_path: Path) -> None:
+    """The /issue-pick front-door command and matching skill must be scaffolded."""
+    run_init(tmp_path)
+
+    pick_cmd = tmp_path / ".cursor" / "commands" / "issue-pick.md"
+    pick_skill = (
+        tmp_path / ".cursor" / "skills" / "issueflow-issue-pick" / "SKILL.md"
+    )
+    assert pick_cmd.is_file()
+    assert pick_skill.is_file()
+
+    cmd_content = pick_cmd.read_text(encoding="utf-8")
+    assert "/issue-pick" in cmd_content
+    assert "/issue-init" in cmd_content
+    assert ".issueflows/" in cmd_content
+
+    skill_content = pick_skill.read_text(encoding="utf-8")
+    assert "name: issueflow-issue-pick" in skill_content
+    assert "disable-model-invocation: true" in skill_content
+
+
 def test_init_rule_documents_knowledge_graph_section(tmp_path: Path) -> None:
     """The generated rule file should mention the optional graphify knowledge graph."""
     run_init(tmp_path)

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -55,8 +55,8 @@ def test_resolve_output_path() -> None:
 
 
 def test_manifest_entry_count() -> None:
-    # 9 commands + 1 rule + 1 doc + 12 skills = 23
-    assert len(TEMPLATE_MANIFEST) == 23
+    # 10 commands + 1 rule + 1 doc + 13 skills = 25
+    assert len(TEMPLATE_MANIFEST) == 25
 
 
 def test_manifest_has_expected_commands_and_skills() -> None:
@@ -64,6 +64,7 @@ def test_manifest_has_expected_commands_and_skills() -> None:
     template_names = {name for name, _ in TEMPLATE_MANIFEST}
     for command in (
         "iflow",
+        "issue-pick",
         "issue-init",
         "issue-plan",
         "issue-start",
@@ -76,6 +77,7 @@ def test_manifest_has_expected_commands_and_skills() -> None:
         assert f"commands/{command}.md.j2" in template_names
     for skill in (
         "issueflow_iflow",
+        "issueflow_issue_pick",
         "issueflow_issue_init",
         "issueflow_issue_comments",
         "issueflow_issue_plan",
@@ -225,6 +227,53 @@ def test_iflow_treats_branch_derived_n_as_authoritative() -> None:
     assert "02-partly-solved-issues" in rendered
     assert "03-solved-issues" in rendered
     assert "archived-issue guard" in rendered.lower()
+
+
+def test_issue_pick_documents_three_phases_and_fix_shortcut() -> None:
+    """/issue-pick must describe its three phases, ranking inputs, and the `fix` shortcut."""
+    rendered = render_template("commands/issue-pick.md.j2", _default_context())
+    # Three phases.
+    assert "Phase 1" in rendered
+    assert "Phase 2" in rendered
+    assert "Phase 3" in rendered
+    # Parked work is the primary candidate source, GitHub the fallback.
+    assert "02-partly-solved-issues" in rendered
+    assert "gh issue list" in rendered
+    # Relevance ranking combines milestone + labels + topical similarity.
+    assert "Milestone" in rendered or "milestone" in rendered
+    assert "Labels" in rendered or "label" in rendered
+    # `fix` shortcut creates a new issue every time.
+    assert "fix" in rendered
+    assert "gh issue create" in rendered
+    # Delegates capture to /issue-init and hands off to /issue-plan.
+    assert "/issue-init" in rendered
+    assert "/issue-plan" in rendered
+    # Off-path: not auto-dispatched by /iflow.
+    assert "off-path" in rendered.lower()
+    # Phase B (auto sub-issue creation) is explicitly out of scope.
+    assert "Phase B" in rendered
+
+
+def test_issue_pick_skill_mirrors_command() -> None:
+    """The issue-pick skill must carry the same front-door flow and frontmatter."""
+    rendered = render_template(
+        "skills/issueflow_issue_pick/SKILL.md.j2", _default_context()
+    )
+    assert "name: issueflow-issue-pick" in rendered
+    assert "disable-model-invocation: true" in rendered
+    assert "Phase 1" in rendered
+    assert "Phase 2" in rendered
+    assert "Phase 3" in rendered
+    assert "/issue-init" in rendered
+    assert "/issue-plan" in rendered
+
+
+def test_iflow_does_not_auto_dispatch_issue_pick() -> None:
+    """/iflow must list /issue-pick among the explicit-only, never-auto-dispatched commands."""
+    cmd = render_template("commands/iflow.md.j2", _default_context())
+    skill = render_template("skills/issueflow_iflow/SKILL.md.j2", _default_context())
+    assert "/issue-pick" in cmd
+    assert "/issue-pick" in skill
 
 
 def test_issue_init_mentions_branch_preflight_and_archive_guard() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "issue-flow"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Adds a new **`/issue-pick`** slash command (plus the matching `issueflow-issue-pick` Agent Skill) — the front door that runs *before* `/issue-init` to help choose what to work on next.

- **Phase 1 — choose:** prefer parked work in `02-partly-solved-issues/`; otherwise rank open GitHub issues (`gh issue list`) by **milestone + labels + topical similarity** to recently solved work and ask the user to confirm a shortlist pick. A `fix` shortcut creates a **new** `chore: general fixes` issue every time.
- **Phase 2 — branch:** require a clean tree, branch off the default (`git switch -c <N>-<slug>`), then delegate to the `/issue-init` flow.
- **Phase 3 — hand off:** ask whether to continue with `/issue-plan` (never auto-runs it).
- **Off-path:** `/iflow` never auto-dispatches to `/issue-pick` (it creates GitHub issues and branches).
- Registered both templates in `TEMPLATE_MANIFEST`; threaded `/issue-pick` through the `iflow` command/skill off-path lists, the workflow doc, the rules file, and the README. Patch version bump 0.3.1 → 0.3.2 + `HISTORY.md` entry.

**Out of scope (Phase B follow-up):** automated breakdown of an over-large issue into sub-issues created on GitHub and parked under `02-partly-solved-issues/`. The command only *mentions* the option for now.

## Test plan

- [x] `uv run pytest` — 110 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `issue-flow update .` regenerates `.cursor/commands/issue-pick.md` + `.cursor/skills/issueflow-issue-pick/SKILL.md`
- [x] Manually run `/issue-pick` end-to-end (survey → branch → init → handoff) and `/issue-pick fix`

Closes #63

Made with [Cursor](https://cursor.com)