### PR TITLE
Set up Cursor Cloud dev environment for issue-flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,22 @@ Keep status files accurate. Use an explicit checkbox in the status file:
   never auto-run.
 - Only commit when explicitly asked.
 
+## Cursor Cloud specific instructions
+
+- This is a `uv`-managed CLI (Python 3.13, pinned in `.python-version`). `uv` is
+  installed at `~/.local/bin` and added to `~/.bashrc`; `uv sync` provisions the
+  matching interpreter automatically. Standard commands live in the "Common
+  commands" section above (`uv run pytest`, `uv run ruff check src/ tests/`).
+- The "application" is the `issue-flow` CLI, exercised end-to-end by scaffolding
+  a throwaway project: `git init` an empty dir, then
+  `uv run --project /workspace issue-flow init . --skip-dep-check`. Use
+  `--skip-dep-check` in headless/cloud runs to avoid the interactive `git`/`gh`
+  dependency-check prompt.
+- `graphify` is installed as a `uv` tool (`uv tool install graphifyy`), so
+  `graphify update .` works without an LLM key (AST-only). It rewrites the
+  tracked `graphify-out/` tree and leaves untracked `graphify-out/cache/`
+  files — revert/clean those if you did not intend to commit a graph rebuild.
+
 <!-- BEGIN issue-flow (managed: do not edit this block) -->
 # Issue-flow best practices
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `issue-flow` CLI in Cursor Cloud and documents the non-obvious bits for future agents.

- Installs `uv` (on `PATH` via `~/.bashrc`), provisions Python 3.13, and runs `uv sync`.
- Installs `graphifyy` as a `uv` tool so `graphify update .` (AST-only) is available to cloud agents.
- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with durable run/test/scaffold caveats.

The startup **update script** is `uv sync` + `uv tool install graphifyy` (both idempotent).

## Verification

- ✅ `uv run ruff check src/ tests/` — all checks passed
- ✅ `uv run pytest` — 147 passed
- ✅ `uv run issue-flow init .` — scaffolded 29 files into a fresh git project (hello-world)
- ✅ `graphify update .` — rebuilt 1217 nodes / 1596 edges (graph output reverted to keep the tree clean)

[devenv_verification.log](https://cursor.com/agents/bc-7d5a424d-af6d-4a52-9550-60cc3cbe171b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdevenv_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d5a424d-af6d-4a52-9550-60cc3cbe171b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d5a424d-af6d-4a52-9550-60cc3cbe171b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

