### PR TITLE
Document editable uv tool dependency-refresh gotcha (#94)

### DIFF
--- a/.issueflows/03-solved-issues/issue94_original.md
+++ b/.issueflows/03-solved-issues/issue94_original.md
@@ -1,0 +1,13 @@
+# Issue #94: missing requirement - tomlkit
+
+Source: https://github.com/jepegit/issue-flow/issues/94
+
+## Original issue text
+
+When running issue-flow I get the following error (on most recent beta version):
+
+ModuleNotFoundError: No module named 'tomlkit'
+
+It should be added as a requirement.
+
+Please check the codebase and make sure our pyproject.toml has all the needed requirements.

--- a/.issueflows/03-solved-issues/issue94_plan.md
+++ b/.issueflows/03-solved-issues/issue94_plan.md
@@ -1,0 +1,84 @@
+# Issue #94 plan — missing requirement (tomlkit)
+
+## Goal
+
+Guarantee `pyproject.toml` declares every runtime third-party dependency the
+package imports, and add a regression guard so a future "missing requirement"
+(like the reported `ModuleNotFoundError: No module named 'tomlkit'`) cannot recur
+silently.
+
+## Findings (investigation already done)
+
+- `tomlkit>=0.15.0` is **already declared** in `pyproject.toml` (line 24) and
+  present in `uv.lock`. It was added in commit `a4d9a0d` (#86) in the *same*
+  commit that introduced its import in `src/issue_flow/modes.py`.
+- `tomlkit` is genuinely needed: `modes.write_active_mode()` uses it to
+  round-trip `config.toml` while preserving user comments/formatting (stdlib
+  `tomllib` is read-only).
+- Full import audit of `src/issue_flow/**/*.py` (top-level + function-level):
+  the only third-party imports are `jinja2`, `dotenv` (python-dotenv), `rich`,
+  `tomlkit`, `typer` — **all declared**. Everything else is stdlib (`tomllib`,
+  `shutil`, `subprocess`, `re`, `json`, `os`, `sys`, `importlib`, `pathlib`,
+  `dataclasses`, `typing`) or intra-package (`issue_flow.*`).
+- Conclusion: the source tree at HEAD has **no missing requirement**. The
+  reported error came from a **stale installed tool** (`uv tool` venv created
+  before `tomlkit` became a dep / from an older build). Confirmed: invoking the
+  global `issue-flow` binary still raises the exact `tomlkit` error even though
+  source + lock are correct.
+
+## Constraints
+
+- Respect the `uv` toolchain (`uv run pytest`, `uv add`); never bare `python`/`pip`.
+- Python 3.13+ (`sys.stdlib_module_names` available).
+- Keep the change small and in-scope: a regression test, not a refactor.
+
+### Prior art
+
+- `.issueflows/00-tools/` — empty (no existing dependency-audit helper).
+- `tests/test_dependencies.py` — covers *external CLI* deps (git/gh/graphify),
+  **not** Python package deps. New test complements it; mirror its style.
+- No existing packaging/metadata test found (grep: none import
+  `importlib.metadata` in tests).
+
+## Approach
+
+1. **No source change for tomlkit** — it is already correctly declared; confirm
+   only.
+2. **Add a regression guard** `tests/test_packaging.py`:
+   - Read declared deps from `pyproject.toml` via `tomllib`
+     (`[project].dependencies`), parse out distribution names.
+   - Walk `src/issue_flow/**/*.py`, parse each with `ast`, collect top-level
+     module names from every `import` / `from ... import`.
+   - Drop stdlib (`sys.stdlib_module_names`) and the package's own `issue_flow`.
+   - Map remaining import names → distribution names via
+     `importlib.metadata.packages_distributions()` (handles `dotenv` →
+     `python-dotenv`).
+   - Assert every required distribution appears in declared deps; fail with a
+     clear message naming the undeclared import + module if not.
+   - This test would have failed had #86 added the `tomlkit` import without the
+     dep, exactly the class of bug #94 reports.
+3. **Release** — the installed-tool fix is to republish so users reinstall; the
+   version bump + publish are handled at `/iflow-close` (`uv version --bump`).
+
+## Files to touch
+
+- `tests/test_packaging.py` (new) — the import-vs-declared-deps regression test.
+- (At `/iflow-close`) `HISTORY.md` + version bump — not part of `/iflow-start`.
+
+## Test strategy
+
+- `uv run pytest tests/test_packaging.py` (and full `uv run pytest`).
+- `uv run ruff check src/ tests/`.
+- Sanity-check the guard works by mentally confirming it flags an undeclared
+  import (optionally a temporary local check, reverted).
+
+## Open questions
+
+- **Scope:** is adding the regression test (option above) the desired
+  deliverable, or do you only want a confirmation that `tomlkit` is declared
+  (close as already-fixed, just bump+republish)? Recommended: add the test — it
+  is the durable fix and matches "make sure pyproject has all needed
+  requirements."
+- **Installed-tool note:** should I add a short troubleshooting note (reinstall
+  `uv tool install --force issue-flow`) to the README, or leave that out of
+  scope? Recommended: leave out unless you want it.

--- a/.issueflows/03-solved-issues/issue94_status.md
+++ b/.issueflows/03-solved-issues/issue94_status.md
@@ -1,0 +1,43 @@
+# Issue #94 status — missing requirement (tomlkit)
+
+- [x] Done
+
+## Outcome
+
+No package code change required. Investigation showed `tomlkit>=0.15.0` is
+**already declared** in `pyproject.toml` and present in `uv.lock` (added in #86,
+the same commit that introduced its import in `src/issue_flow/modes.py`).
+
+## What was done
+
+- **Dependency audit** of `src/issue_flow/**/*.py` (top-level + function-level
+  imports): the only third-party imports are `jinja2`, `dotenv`
+  (python-dotenv), `rich`, `tomlkit`, `typer` — all declared. Everything else is
+  stdlib or intra-package. No missing requirement remains in source.
+- **Root cause identified:** the reported `ModuleNotFoundError: No module named
+  'tomlkit'` came from a **stale editable `uv tool` install** (installed binary
+  reported `v0.4.1a3`, predating #86) running live source against a venv
+  resolved before `tomlkit` was a dependency. Not a source bug.
+- **Documented the gotcha** in
+  `.issueflows/04-designs-and-guides/this-project.md` (new "Editable `uv tool`
+  install — dependency refresh gotcha" subsection): rerun
+  `uv tool install --force --editable .` after any dependency change; this is
+  distinct from the `issue-flow update` subcommand.
+- Also filled out the rest of `this-project.md` (was a TODO scaffold).
+
+## Fix for affected users
+
+Reinstall the tool so the venv re-resolves deps:
+
+```bash
+uv tool install --force --editable .
+```
+
+A republished beta likewise carries the already-declared `tomlkit` dep for
+fresh installs.
+
+## Not done (deliberately, per user)
+
+- No regression test added (the proposed `tests/test_packaging.py` import-vs-deps
+  guard was discussed but the user opted to keep scope minimal).
+- No README troubleshooting note.

--- a/.issueflows/04-designs-and-guides/this-project.md
+++ b/.issueflows/04-designs-and-guides/this-project.md
@@ -2,31 +2,107 @@
 
 ## What this project is
 
-TODO: Summarize the project in one short paragraph. Mention what it does, who it is for, and the main outcome it produces.
+**issue-flow** is a small Python CLI that scaffolds a lightweight,
+agent-friendly issue-tracking workflow into *other* projects. Running
+`issue-flow init` writes a `.issueflows/` tracking tree plus editor skills,
+rules, and slash-command files so AI agents can pick up GitHub issues, plan
+work, and land PRs in a consistent way. **This repo *is* the tool** — not a
+project scaffolded by it (though it dogfoods its own workflow).
 
 ## Stack / runtime
 
-- TODO: Primary language(s), runtime versions, package manager(s), and major frameworks.
-- TODO: External services, CLIs, or local tools that agents should know about.
+- **Language/runtime:** Python **3.13+** (pinned in `.python-version`).
+- **Package manager:** **`uv`** exclusively (uv-managed `.venv`). Never `pip`,
+  `pip-tools`, or `poetry`.
+- **Build backend:** `uv_build`. Entry point: `issue-flow = "issue_flow.cli:main"`.
+- **Runtime deps:** `jinja2`, `python-dotenv`, `rich`, `tomlkit`, `typer`
+  (declared in `pyproject.toml`; `tomlkit` round-trips `config.toml` preserving
+  comments, stdlib `tomllib` is read-only). Dev group: `pytest`, `ruff`.
+- **External CLIs agents should know about:** `git` and `gh` (required for the
+  issue workflow), plus optional `graphify` (knowledge-graph integration,
+  installed as its own `uv` tool).
 
 ## How to run / test
 
 ```bash
-TODO: command to install or sync dependencies
-TODO: command to run the main test suite
-TODO: command to run lint/format checks
+uv sync                          # install/refresh deps from the lock file
+uv run pytest                    # run the test suite
+uv run ruff check src/ tests/    # lint
+uv version --bump <part>         # bump version (used by /iflow-close)
 ```
+
+Exercise the CLI end-to-end by scaffolding a throwaway project: `git init` an
+empty dir, then `uv run --project <repo> issue-flow init . --skip-dep-check`
+(`--skip-dep-check` avoids the interactive git/gh prompt in headless runs).
+
+### Editable `uv tool` install — dependency refresh gotcha
+
+When developing, you typically install issue-flow as a **local editable `uv`
+tool** so the `issue-flow` binary on `PATH` runs your live source:
+
+```bash
+uv tool install --force --editable .
+```
+
+Key behaviour:
+
+- The editable link means **code edits apply instantly** — no reinstall needed.
+- But the tool's isolated venv only contains the dependencies resolved **at
+  install time**. If you **add / remove / bump a dependency** in
+  `pyproject.toml`, the linked code sees the change but the venv does **not** →
+  you get `ModuleNotFoundError` (this is exactly what caused issue #94:
+  `No module named 'tomlkit'` from a venv resolved before `tomlkit` was added).
+- **Fix:** rerun `uv tool install --force --editable .` to rebuild the venv and
+  re-resolve deps. `uv tool upgrade issue-flow` alone does **not** reliably
+  re-resolve a local editable install.
+- Do **not** confuse this with the `issue-flow update` *subcommand* — that
+  re-scaffolds `.issueflows/`/skills into a target project and touches nothing
+  in the tool's venv.
+
+> Rule of thumb: edit code → no action. Change a dependency → rerun
+> `uv tool install --force --editable .`.
 
 ## Conventions
 
-- TODO: Branch, commit, formatting, typing, testing, or review conventions that are specific to this project.
-- TODO: Any project-specific workflow details that are easy for agents to miss.
+- **Templates are the source of truth.** Files generated into target projects
+  (slash commands, skills, the always-on rule) come from
+  `src/issue_flow/templates/`. When changing scaffold behaviour, edit the
+  **templates**, not any already-rendered copy.
+- **Branches:** do issue work on an issue branch named `<N>-<short-slug>`, not
+  the default branch. PRs are assumed **squash-merged**; run `/iflow-cleanup`
+  after merge.
+- **Commits:** only commit when explicitly asked.
+- **Issue workflow:** this repo follows the issue-flow lifecycle it ships —
+  `/iflow-init` → `/iflow-plan` → `/iflow-start` → `/iflow-close` →
+  `/iflow-cleanup` (with `/iflow` as the smart dispatcher, `/iflow-pick` /
+  `/iflow-pause` / `/iflow-yolo` off-path). Keep status files accurate with an
+  explicit `- [x] Done` / `- [ ] Done` checkbox.
+- **Config:** reads a `.env` from the project root (`ISSUEFLOW_DIR`,
+  `ISSUEFLOW_AGENT_DIR`, `ISSUEFLOW_DOCS_DIR`, `ISSUEFLOW_HISTORY_FILE`).
+  Project-level toggles live in `.issueflows/config.toml` under `[issueflow]`
+  (e.g. `mode`, `caveman_default`, `grill_me_default`).
 
 ## Entry points
 
-- TODO: Main application/package/module entry point.
-- TODO: Important directories or files to read first.
+- **CLI:** `src/issue_flow/cli.py` (Typer) — `init` / `update` / `graphify`
+  plus agent-facing subcommands (`agent capture` / `sweep` / `preflight` /
+  `status` / `state`).
+- **Scaffolding logic:** `src/issue_flow/init.py` (writes `.issueflows/` +
+  editor config).
+- **Other core modules:** `config.py` (env/config), `modes.py` (scaffolding
+  modes), `editors.py` (editor profiles), `templating.py` (Jinja2 helpers),
+  `dependencies.py` (git/gh/graphify checks), `gitutils.py`, `agent.py`,
+  `graphify.py`.
+- **Templates:** `src/issue_flow/templates/` (`commands/`, `skills/`, `rules/`).
+- **Tests:** `tests/` (pytest). **Read first:** `AGENTS.md`, this file, then the
+  module matching the area you're changing.
 
 ## Non-goals / known limitations
 
-- TODO: Scope boundaries, known caveats, or things this project intentionally does not do.
+- Not a full issue tracker or GitHub replacement — it scaffolds a
+  **file-based**, agent-friendly workflow around existing GitHub issues.
+- Targets the **Cursor** editor surface primarily (skills/rules/commands);
+  other editors are partially supported via editor profiles.
+- The `graphify` knowledge-graph integration is **optional** and off-path
+  (never auto-run); ignore graph guidance when `graphify-out/` is absent.
+- Requires Python **3.13+**; no support for older interpreters.


### PR DESCRIPTION
## Summary

Issue #94 reported `ModuleNotFoundError: No module named 'tomlkit'`. Investigation shows **no source bug**:

- `tomlkit>=0.15.0` has been declared in `pyproject.toml` and `uv.lock` since #86 (the same commit that added its import in `src/issue_flow/modes.py`, where it round-trips `config.toml` preserving comments).
- A full audit of third-party imports under `src/issue_flow/**/*.py` confirms every runtime requirement (`jinja2`, `python-dotenv`, `rich`, `tomlkit`, `typer`) is already declared; everything else is stdlib or intra-package.

**Root cause:** a stale editable `uv tool` install — the linked source was current, but the tool venv was resolved (at `v0.4.1a3`) before `tomlkit` became a dependency. Fix for affected users: `uv tool install --force --editable .`.

## Changes

- Document the editable-install dependency-refresh gotcha in `.issueflows/04-designs-and-guides/this-project.md`, and fill out the previously-stub project brief.
- Archive #94 tracking files to `03-solved-issues`.

No package/code change (and so no version bump or `HISTORY.md` entry); a republished beta carries the already-declared dep for fresh installs.

## Test plan

- [x] `uv run pytest` — 269 passed

Refs #94

Made with [Cursor](https://cursor.com)