### PR TITLE
Add a --version option to the issue-flow CLI

### DIFF
--- a/.issueflows/03-solved-issues/issue104_original.md
+++ b/.issueflows/03-solved-issues/issue104_original.md
@@ -1,0 +1,9 @@
+# Issue #104: Iterative small fixes
+
+Source: https://github.com/jepegit/issue-flow/issues/104
+
+## Original issue text
+
+Interactive `/iflow-fix` session.
+
+Individual fixes in this session are recorded as dated bullets in the status markdown (`.issueflows/01-current-issues/issue<N>_status.md`) and landed together via `/iflow-close`.

--- a/.issueflows/03-solved-issues/issue104_status.md
+++ b/.issueflows/03-solved-issues/issue104_status.md
@@ -1,0 +1,9 @@
+# Issue #104 status — Iterative small fixes
+
+Interactive `/iflow-fix` session on branch `104-iterative-small-fixes`. Each confirmed fix is recorded as a dated bullet below; the session lands via `/iflow-close`.
+
+- [x] Done
+
+## Iterative fixes log
+
+- **2026-07-02** — Added `--version` eager option to the root Typer callback in `src/issue_flow/cli.py` (prints `issue-flow <version>` via `importlib.metadata`); test `test_cli_version_option` added in `tests/test_cli.py`.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@ than the GitHub release notes they link to.
 ## [Unreleased]
 
 - Align issues with plan. (#85)
+- **New `--version` flag (#104).** `issue-flow --version` prints the installed package version (read from package metadata) and exits, implemented as an eager option on the root Typer callback. Landed via an interactive `/iflow-fix` session.
 
 ## [0.4.1b3] - 2026-06-28
 

--- a/src/issue_flow/cli.py
+++ b/src/issue_flow/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from importlib.metadata import version as _package_version
 from pathlib import Path
 
 import typer
@@ -61,8 +62,22 @@ _SKILL_LEVEL_HELP = (
 )
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        _console.print(f"issue-flow {_package_version('issue-flow')}")
+        raise typer.Exit()
+
+
 @app.callback()
-def _callback() -> None:
+def _callback(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the issue-flow version and exit.",
+    ),
+) -> None:
     """Agents should behave. Let them follow the issue flow."""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,15 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+def test_cli_version_option(runner: CliRunner) -> None:
+    """`issue-flow --version` must print the package version and exit 0."""
+    from importlib.metadata import version
+
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert version("issue-flow") in result.stdout
+
+
 def test_cli_lists_graphify_command(runner: CliRunner) -> None:
     """`issue-flow --help` must mention the `graphify` command."""
     result = runner.invoke(app, ["--help"])


### PR DESCRIPTION
## Summary

- Adds an eager `--version` option to the root Typer callback: `issue-flow --version` prints `issue-flow <version>` (read from package metadata) and exits 0. Previously this errored with "No such option".
- Landed via an interactive `/iflow-fix` session; session notes archived under `.issueflows/03-solved-issues/`.

## Test plan

- `uv run issue-flow --version` prints the installed version.
- New regression test `test_cli_version_option`; full suite passes (283 tests).

Closes #104

Made with [Cursor](https://cursor.com)