### PR TITLE
Add README attribution for the grill-me skill source

### DIFF
--- a/.issueflows/03-solved-issues/issue108_original.md
+++ b/.issueflows/03-solved-issues/issue108_original.md
@@ -1,0 +1,11 @@
+# Issue #108 — lacking ref to grill-me
+
+- **GitHub:** https://github.com/jepegit/issue-flow/issues/108
+- **Author:** jepegit (Jan Petter Maehlen)
+- **Created:** 2026-07-02
+- **Labels:** yolo
+- **Milestone:** none
+
+## Original description
+
+In the readme, I could not se any ref to the grill-me skill repo/author. If missing, please add.

--- a/.issueflows/03-solved-issues/issue108_plan.md
+++ b/.issueflows/03-solved-issues/issue108_plan.md
@@ -1,0 +1,25 @@
+# Issue #108 — plan
+
+## Goal
+
+README lacks attribution for the `grill-me` Agent Skill. Add a reference to its
+source repo/author, matching the existing `caveman` attribution pattern.
+
+## Approach
+
+- The skill was adapted from Matt Pocock's `grill-me` skill (issue #32,
+  `.issueflows/04-designs-and-guides/grill-me-skill.md`).
+- Source repo: https://github.com/mattpocock/skills (MIT licensed, `LICENSE` in
+  repo root).
+- Add a row to the acknowledgements table in `README.md` (the table that already
+  credits `JuliusBrussee/caveman`), describing it as the inspiration for the
+  bundled `grill-me` skill, adapted to issue-flow's planning workflow.
+
+## Files to touch
+
+- `README.md` (one table row)
+
+## Test strategy
+
+- `uv run pytest` (full suite; docs-only change, tests guard against regressions)
+- Visual check of the table markdown.

--- a/.issueflows/03-solved-issues/issue108_status.md
+++ b/.issueflows/03-solved-issues/issue108_status.md
@@ -1,0 +1,15 @@
+# Issue #108 — status
+
+- [x] Done
+
+## What was done
+
+- Added an attribution row for [mattpocock/skills](https://github.com/mattpocock/skills)
+  (source of the `grill-me` skill, MIT) to the Acknowledgements table in
+  `README.md`, mirroring the existing `caveman` row.
+- Verified the source repo and license via the GitHub API and the issue #32
+  design doc (`.issueflows/04-designs-and-guides/grill-me-skill.md`).
+
+## Remaining work
+
+None.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ than the GitHub release notes they link to.
 
 ## [Unreleased]
 
+- Added a README Acknowledgements row crediting [mattpocock/skills](https://github.com/mattpocock/skills) as the source of the bundled `grill-me` Agent Skill. (#108)
 - Align issues with plan. (#85)
 - **Label-driven yolo flow (#106).** Issue labels can now select the flow: when `/iflow-pick` picks an issue carrying the (configurable) yolo label, it routes it through `/iflow-yolo` with one combined confirmation. Controlled by two new `[issueflow]` keys in `.issueflows/config.toml` — `label_flows` (default `true`) and `yolo_label` (default `"yolo"`), with `ISSUEFLOW_LABEL_FLOWS` / `ISSUEFLOW_YOLO_LABEL` env fallbacks; `issue-flow config add` now writes all six keys. The yolo chain also closes the loop: a new `yolo` token on `/iflow-close` writes the changelog bullet without a confirm prompt, merges the PR via `gh pr merge --squash` (`--squash --auto` fallback when blocked), then switches back to the default branch and pulls. Branch deletion still belongs to `/iflow-cleanup`.
 - **New `--version` flag (#104).** `issue-flow --version` prints the installed package version (read from package metadata) and exits, implemented as an eager option on the root Typer callback. Landed via an interactive `/iflow-fix` session.

--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Thanks to the authors and communities behind these projects:
 | Project | How issue-flow uses it | License |
 | --- | --- | --- |
 | [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) | Inspiration for the bundled `caveman` Agent Skill (terse, token-greedy response style). Our version is a trimmed adaptation — full intensity only, English only. | [MIT](https://github.com/JuliusBrussee/caveman/blob/main/LICENSE) |
+| [mattpocock/skills](https://github.com/mattpocock/skills) | Matt Pocock's `grill-me` skill inspired the bundled `grill-me` Agent Skill (relentless planning interview). Our version is adapted to issue-flow's planning workflow, feeding conclusions into `issue<N>_plan.md`. | [MIT](https://github.com/mattpocock/skills/blob/main/LICENSE) |
 | [safishamsi/graphify](https://github.com/safishamsi/graphify) (`graphifyy` on PyPI) | Powers the optional knowledge-graph integration (`issue-flow graphify`, `graphify-out/`). Installed separately and invoked as an external tool. | [MIT](https://github.com/safishamsi/graphify/blob/main/LICENSE) |
 | [Typer](https://github.com/fastapi/typer) | The `issue-flow` command-line interface. | MIT |
 | [Rich](https://github.com/Textualize/rich) | Formatted terminal output during `init` / `update`. | MIT |


### PR DESCRIPTION
## Summary

- Adds a row to the README Acknowledgements table crediting [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) as the source the bundled `grill-me` Agent Skill was adapted from, mirroring the existing `caveman` attribution.
- Records the change under `## [Unreleased]` in `HISTORY.md` and archives the issue 108 tracking files.

## Test plan

- `uv run pytest` — 303 passed.
- Visual check of the Acknowledgements table rendering.

Closes #108

Made with [Cursor](https://cursor.com)