### PR TITLE
Adopt writing-great-skills best practices for shipped skill templates

### DIFF
--- a/.cursor/skills/caveman/SKILL.md
+++ b/.cursor/skills/caveman/SKILL.md
@@ -31,7 +31,7 @@ English only. Caveman applies to English output; do not garble other languages.
 
 ## Intensity
 
-Single level: **full**. Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations.
+Single level: **full**. Classic caveman — every rule above applies at full strength; there is no milder setting.
 
 Example — "Why React component re-render?"
 - "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."

--- a/.cursor/skills/iflow-archive/SKILL.md
+++ b/.cursor/skills/iflow-archive/SKILL.md
@@ -1,25 +1,19 @@
 ---
 name: iflow-archive
 description: >-
-  Run the /iflow-archive workflow: condense selected solved issue groups under
-  .issueflows/03-solved-issues/ into a single dated
-  YYYY-MM-DD_archived_issues.md summary file that records the pre-archive git
-  ref for recovery, then delete the original issue<N>_* files. Off-path:
-  never auto-dispatched; destructive, one consolidated confirm.
+  Condense old solved issue groups into one dated summary file, then delete
+  the originals. Destructive, one consolidated confirm.
 disable-model-invocation: true
 ---
 
 # issue-flow — archive solved issues (`/iflow-archive`)
 
-Follow this skill when the user wants to **shrink the solved-issues archive**:
+Follow this skill to **shrink the solved-issues archive**:
 old `issue<N>_*` groups under `.issueflows/03-solved-issues/` are
 summarised into one dated markdown file and the originals are deleted (they
 stay recoverable through git history).
 
-## When to use
-
-- The user runs `/iflow-archive`, mentions "archive solved issues", "condense the issue archive", or complains the solved folder has grown too big.
-- Do **not** use this to park or close an active issue — that is `/iflow-pause` / `/iflow-close`. This skill only touches `.issueflows/03-solved-issues/`.
+Do **not** use this to park or close an active issue — that is `/iflow-pause` / `/iflow-close`. This skill only touches `.issueflows/03-solved-issues/`.
 
 ## Input
 

--- a/.cursor/skills/iflow-cleanup/SKILL.md
+++ b/.cursor/skills/iflow-cleanup/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: iflow-cleanup
 description: >-
-  Run the /iflow-cleanup workflow: detect merge status, switch to the default
-  branch, and — with a single consolidated confirm — delete every local branch
-  already reachable from origin/<default> (including squash-merges). Never -D.
+  Post-merge branch hygiene: switch to the default branch and delete merged
+  local branches under one consolidated confirm. Never -D.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue cleanup (`/iflow-cleanup`)
 
-Follow this skill when the user wants to **run post-merge branch hygiene** after a PR has been merged.
-
-## When to use
-
-- The user runs `/iflow-cleanup`, mentions **issue-cleanup**, or asks you to delete local branches whose PRs have merged.
-- The PR opened by `/iflow-close` just merged and the user wants the standard post-merge tidy-up.
+Follow this skill to **run post-merge branch hygiene** after a PR has been merged (typically the PR opened by `/iflow-close`).
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow-close/SKILL.md
+++ b/.cursor/skills/iflow-close/SKILL.md
@@ -1,33 +1,26 @@
 ---
 name: iflow-close
 description: >-
-  Run the /iflow-close workflow: verify tests, optional uv semver bump, update
-  issue status and folder locations, commit, push, and open a PR with a clear
-  summary. Post-merge branch cleanup now lives in /iflow-cleanup.
+  Finish and land the focus issue: tests, optional version bump, status
+  update, commit, push, and PR.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue close (`/iflow-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.
+Follow this skill to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.
 
-Post-merge branch hygiene now lives in `/iflow-cleanup` — this skill no longer deletes branches.
-
-## When to use
-
-- The user runs `/iflow-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
+Post-merge branch hygiene lives in `/iflow-cleanup` — this skill never deletes branches.
 
 ## Optional version bump (command input)
 
 If the user included text after `/iflow-close` that requests a version bump:
 
-- **`bump`** (no level) → **pre-release-aware default**: stay on the current channel (alpha→`alpha`, beta→`beta`, rc→`rc`, dev→`dev`) or `patch` when the current version is already stable.
-- **A named level** → `uv version --bump <level>` for any uv level: `patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev` (`dev` must be paired, e.g. `--bump patch --bump dev`).
-- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`, "promote to beta" → `beta`); ask once if ambiguous. Never auto-pick `major`.
+- **`bump`** (no level) → apply the pre-release-aware default.
+- **A named level** (`patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev`) → use exactly that.
+- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`); ask once if ambiguous. Never auto-pick `major`.
 
-The exact semantics and the default rule live in `.cursor/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth.
-
-When a bump applies: read `.cursor/skills/iflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+The exact semantics and the default rule live in `.cursor/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth. When a bump applies: read it, then run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
 
 ## Changelog update tokens (command input)
 
@@ -60,7 +53,7 @@ Keep scope tight to what this step requires.
 
 1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. **Ruff (when present):** if the project uses ruff (`[tool.ruff]` in `pyproject.toml`, ruff in dev dependencies, or `.issueflows/04-designs-and-guides/python-quality-tools.md` exists), run auto-fix lint through the documented Python runner before committing — e.g. `uv run ruff check --fix …` then `uv run ruff format …` (match paths to what the project documents). Skim the diff; avoid bundling unrelated changes. Confirm that any design decisions or good practices that emerged from this issue are captured under `.issueflows/04-designs-and-guides/` before committing.
 
-2. **Optional version bump** — If the user asked for a bump (see above), follow `.cursor/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `.cursor/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <level>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
 3. **Update `HISTORY.md`** — Unless the user passed `nohistory`, follow `.cursor/skills/iflow-history-update/SKILL.md`. If step 2 did not bump the version, append a bullet to the `## [Unreleased]` section. If step 2 bumped the version, promote `## [Unreleased]` to `## [<new_version>] - <YYYY-MM-DD>` and open a fresh empty `## [Unreleased]` above it. Show the diff and confirm once before writing. Skip with a note if `HISTORY.md` does not exist at the project root. With the `yolo` token, do not ask — decide yourself and write the bullet (issue title, or `log "..."` text) directly.
 

--- a/.cursor/skills/iflow-comments/SKILL.md
+++ b/.cursor/skills/iflow-comments/SKILL.md
@@ -1,24 +1,16 @@
 ---
 name: iflow-comments
 description: >-
-  Triage a GitHub issue's comment thread into a curated, bucketed summary
-  (additional tasks, clarifications, superseded) for inclusion in
-  issue<N>_original.md. Invoked by /iflow-init; also reusable when re-triaging
-  comments later in an issue's lifecycle.
+  Triage a GitHub issue's comment thread into the curated, bucketed summary
+  section of issue<N>_original.md.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue comments triage
 
-Follow this skill when you need to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `.issueflows/01-current-issues/issue<N>_original.md`.
+Follow this skill to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `.issueflows/01-current-issues/issue<N>_original.md`.
 
-It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments.
-
-## When to use
-
-- `/iflow-init` just fetched an issue with a non-empty `comments` array and needs to write the `## Comments (curated summary)` section.
-- You are re-running triage on an already-captured issue because new comments have arrived (the issue body text must stay unchanged; only the curated section is rewritten).
-- Any workflow that needs to understand "what does the comment thread actually ask us to do?" without pasting the raw thread into a file.
+It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments. It also covers re-triage of an already-captured issue when new comments arrive (the issue body text stays unchanged; only the curated section is rewritten).
 
 
 ### MODEL & EXECUTION DIRECTIVE
@@ -92,7 +84,6 @@ Formatting rules:
 - Each bucket's bullet is itself a list if there is more than one item — nest concrete bullets under the bold label.
 - **Drop any bucket that is empty** — do not leave `- **Additional tasks**: ` with no content.
 - **Always keep the `_Note: ..._` footer** when the section exists. Use the total `comments` length for `<count>` and the `author.login` + date of the most recent non-dropped comment for `@<login>` / `<date>`.
-- Use UTF-8 markdown. No leading/trailing blank lines inside the section beyond what's shown.
 
 ## Edge cases
 
@@ -106,5 +97,4 @@ Formatting rules:
 ## Constraints
 
 - This skill only writes into the `## Comments (curated summary)` section of `issue<N>_original.md`. It never touches the issue body, the status file, or the plan file.
-- It never calls `gh` itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.
-- It never talks to the network beyond what the caller has already fetched.
+- It never calls `gh` or the network itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.

--- a/.cursor/skills/iflow-fix/SKILL.md
+++ b/.cursor/skills/iflow-fix/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: iflow-fix
 description: >-
-  Run the /iflow-fix interactive session: set up one long-lived branch + GitHub
-  issue for a stream of small iterative fixes, then loop — each fix gets a short
-  plan, is implemented only on confirmation, and is recorded as a dated bullet in
-  issue<N>_status.md. Finish with /iflow-close. Off-path: never auto-dispatched by
-  /iflow. Always creates a GitHub issue (gh); GitLab is not supported.
+  Interactive session: one long-lived branch + GitHub issue for a stream of
+  small iterative fixes, landed together via /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — interactive iterative-fix session (`/iflow-fix`)
 
-Follow this skill when the user wants an **ongoing working session** for many small fixes on one branch, rather than a single well-defined deliverable.
-
-## When to use
-
-- The user runs `/iflow-fix`, mentions "iterative fixes", "small fixes session", or "let's just fix things on a branch".
-- They have a bucket of little improvements (small bugs, typos, chores, polish) to knock out together and land via one PR.
+Follow this skill for an **ongoing working session** of many small fixes (small bugs, typos, chores, polish) on one branch, landed via one PR — rather than a single well-defined deliverable.
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-fix` is explicit-only because it creates GitHub issues and branches and drives an open-ended loop. While a session is active, drive it with `/iflow-fix` + `/iflow-close`, not `/iflow`.
 

--- a/.cursor/skills/iflow-graphify/SKILL.md
+++ b/.cursor/skills/iflow-graphify/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: iflow-graphify
 description: >-
-  Run the /iflow-graphify slash command: rebuild the graphify knowledge graph for the
-  project (graphify-out/graph.html, GRAPH_REPORT.md, graph.json) by shelling out
-  to `issue-flow graphify` (or `graphify` directly). Off-path: never auto-dispatched
-  by /iflow. Forwards trailing args verbatim to graphify.
+  Rebuild the graphify knowledge graph (graphify-out/) by shelling out to
+  `issue-flow graphify` or `graphify` directly.
 disable-model-invocation: true
 ---
 
 # issue-flow — graph rebuild (`/iflow-graphify`)
 
-Follow this skill when the user wants to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph.
-
-## When to use
-
-- The user runs `/iflow-graphify`, mentions "rebuild the graph", "refresh graphify", "regenerate `GRAPH_REPORT.md`", or similar.
-- The project has a `graphify-out/` folder that is stale (large refactor, new modules, new docs/papers added) and the user asks to update it.
-- The user installed `graphifyy` for the first time and wants to produce the initial graph.
+Follow this skill to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph — a stale `graphify-out/` after a large refactor, or the initial graph after installing `graphifyy`.
 
 Do **not** use this skill from `/iflow-start`, `/iflow-close`, or `/iflow`. `/iflow-graphify` is opt-in only.
 

--- a/.cursor/skills/iflow-history-update/SKILL.md
+++ b/.cursor/skills/iflow-history-update/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: iflow-history-update
 description: >-
-  Keep HISTORY.md (or equivalent changelog) up to date when landing an issue:
-  append a bullet to [Unreleased], or promote [Unreleased] to a new [x.y.z]
-  release section when a version bump happened. Invoked from /iflow-close.
+  Update the changelog when landing an issue: append a bullet to
+  [Unreleased], or promote it to a release section after a version bump.
 disable-model-invocation: true
 ---
 
 # issue-flow — history update
 
-Use this skill to update the project's changelog file (default **`HISTORY.md`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step.
-
-## When to use
-
-- `/iflow-close` is landing an issue and the project has a changelog file in the repo root.
-- The user did **not** pass `nohistory` / `skip history` on the command line.
+Use this skill to update the project's changelog file (default **`HISTORY.md`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step, and does not run when the user passed `nohistory` / `skip history`.
 
 
 ### MODEL & EXECUTION DIRECTIVE
@@ -34,7 +28,6 @@ Keep scope tight to what this step requires.
 
 1. The changelog file (`HISTORY.md`) exists at the **project root**. If it does not, **skip** this step, print "no `HISTORY.md` — skipping changelog update" and continue the rest of `/iflow-close`. Never create the file from this skill.
 2. The file is in **Keep a Changelog** shape: a top-level `## [Unreleased]` heading, with released versions below as `## [x.y.z] - YYYY-MM-DD` headings. If the shape does not match, **stop and report the mismatch** instead of guessing — let the user fix the file or pass `nohistory`.
-3. UTF-8 read/write with explicit encoding.
 
 ## Inputs from `/iflow-close`
 
@@ -92,7 +85,6 @@ When `/iflow-close` reaches its commit step:
 
 - Read/write only `HISTORY.md` at the project root. Do not touch any other file from this skill.
 - Never create `HISTORY.md` from scratch — scaffolding a starter changelog is out of scope for `issue-flow init` / `update`.
-- If the user passed `nohistory` (or `skip history`) to `/iflow-close`, don't run this skill at all.
 - If the confirm prompt in mode A or mode B is declined, leave `HISTORY.md` untouched and print a short "skipped changelog update" note. The rest of `/iflow-close` continues normally.
 - Preserve existing formatting conventions (bullet style, sentence case, trailing punctuation). Match the style of the nearest existing entries when in doubt.
 - The new bullet's `(#<N>)` suffix is always GitHub issue `#N`, matching the focus issue's number in `.issueflows/01-current-issues/issue<N>_original.md`.

--- a/.cursor/skills/iflow-init/SKILL.md
+++ b/.cursor/skills/iflow-init/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: iflow-init
 description: >-
-  Run the /iflow-init workflow: resolve GitHub issue reference, fetch body
-  and comments with gh, triage the comments via the iflow-comments
-  skill, write issue<number>_original.md under
-  .issueflows/01-current-issues/, and archive other
-  current issues by done status.
+  Capture a GitHub issue locally as issue<number>_original.md and archive
+  other current issues by done status.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue init (`/iflow-init`)
 
-Follow this skill when the user wants to **capture a GitHub issue locally**.
-
-## When to use
-
-- The user runs `/iflow-init`, mentions **issue-init**, or asks to pull an issue into `.issueflows/01-current-issues/`.
-- You need a repeatable checklist without opening the command file.
+Follow this skill to **capture a GitHub issue locally** under `.issueflows/01-current-issues/`.
 
 
 ### MODEL & EXECUTION DIRECTIVE
@@ -53,13 +45,7 @@ Keep scope tight to what this step requires.
 
 3. **Fetch** — `gh issue view <n> --repo owner/repo --json title,body,url,number,comments`. The `comments` field returns an array of `{author.login, body, createdAt, ...}` that step 3a consumes. On failure, report the error and suggest `gh auth login`. After confirming `owner/repo`, change the chat/agent tab title to reflect the issue topic on the form "Issue <issue number> <short description of issue>" (e.g. "Issue 74 cell info").
 
-3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill. Summary of rules:
-   - Process comments chronologically; **later comments win conflicts** with earlier ones.
-   - Sort points into three buckets: **Additional tasks**, **Clarifications / constraints**, **Superseded / retracted**.
-   - Collapse duplicates; drop chit-chat, emoji-only, "LGTM" and bot messages.
-   - Paraphrase — this section is an interpretive summary, not a verbatim dump.
-   - If all comments are noise, skip the curated section entirely.
-   - On open disagreement with no clear winner, log it under *Clarifications* rather than picking a side.
+3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill — it owns the triage rules (chronological precedence, three buckets, noise filtering) and the exact shape of the `## Comments (curated summary)` section.
 
 3.5 **Branch status preflight** (report only) — Run `git fetch --prune`. Report current branch, clean/dirty working tree, and ahead/behind counts vs `origin/<default>` (detect default via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, else `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`). If the current branch matches `^(\d+)-.+` and files for that issue already live in `.issueflows/02-partly-solved-issues/` or `.issueflows/03-solved-issues/`, note that the branch looks stale. Never delete or move anything at this step.
 
@@ -94,4 +80,3 @@ Keep scope tight to what this step requires.
 ## Constraints
 
 - Allowed file operations: create/update the target `*_original.md`, and move pre-existing issue groups per the archive rules. Do not modify unrelated project files.
-- Use UTF-8 for markdown output.

--- a/.cursor/skills/iflow-pause/SKILL.md
+++ b/.cursor/skills/iflow-pause/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: iflow-pause
 description: >-
-  Run the /iflow-pause workflow: update the status file with remaining work,
-  move the issue group to .issueflows/02-partly-solved-issues/,
-  and optionally make a WIP commit and switch to the default branch.
+  Park work on the current issue without closing it: update status, move
+  the group to 02-partly-solved-issues/, optional WIP commit.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue pause (`/iflow-pause`)
 
-Follow this skill when the user wants to **park work on the current issue** without closing it.
-
-## When to use
-
-- The user runs `/iflow-pause`, mentions **issue-pause**, or asks to park / stash / shelve work on an issue to switch context.
-- The issue is **not** done — this is not `/iflow-close`.
+Follow this skill to **park work on the current issue** without closing it. The issue is **not** done — this is not `/iflow-close`.
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow-pick/SKILL.md
+++ b/.cursor/skills/iflow-pick/SKILL.md
@@ -1,23 +1,14 @@
 ---
 name: iflow-pick
 description: >-
-  Run the /iflow-pick front door: help the user choose the next issue (parked
-  work in 02-partly-solved-issues/ first, else rank open GitHub issues by
-  milestone, labels, and topical similarity to recently solved work), optionally
-  create a new general-fixes issue on `fix`, create the issue branch, run
-  /iflow-init, then hand off to /iflow-plan. Off-path: never auto-dispatched by
-  /iflow. Does not auto-create sub-issues.
+  Front door: choose the next issue, create the issue branch, and run
+  /iflow-init.
 disable-model-invocation: true
 ---
 
 # issue-flow — pick next issue (`/iflow-pick`)
 
-Follow this skill when the user wants help **choosing what to work on next** and getting set up to start.
-
-## When to use
-
-- The user runs `/iflow-pick`, mentions "pick the next issue", "what should I work on next?", or "find me an issue".
-- The user is on the default branch with nothing in progress and wants a candidate plus a ready branch.
+Follow this skill to help the user **choose what to work on next** (parked work first, else ranked open GitHub issues) and get set up to start.
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-pick` is explicit-only because it creates GitHub issues and branches.
 
@@ -57,6 +48,8 @@ Keep scope tight to what this step requires.
 7. **Label-driven yolo flow.** If the chosen issue carries the **`yolo`** label (case-insensitive), announce it and fold `/iflow-yolo`'s consolidated confirm into the pick confirmation (one prompt: branch + full `init → plan → start → close yolo` chain). On yes, run Phase 2 then follow the `iflow-yolo` skill **instead of** the Phase 3 handoff — its preflight still applies, but do not re-ask its confirm. Configurable via `label_flows` / `yolo_label` under `[issueflow]` in `.issueflows/config.toml` (re-run `issue-flow update` after changing).
 
 
+
+### Phase 2 — create the branch
 
 1. **Require a clean tree** (`git status --porcelain`). If dirty, **stop** and ask the user to commit/stash.
 2. **Branch off the default** — switch to default, fast-forward, then `git switch -c <N>-<short-slug>` (GitHub numeric convention). Confirm a non-obvious slug.

--- a/.cursor/skills/iflow-plan/SKILL.md
+++ b/.cursor/skills/iflow-plan/SKILL.md
@@ -1,21 +1,14 @@
 ---
 name: iflow-plan
 description: >-
-  Run the /iflow-plan workflow: read the focus issue in
-  .issueflows/01-current-issues/, draft a structured plan
-  in issue<N>_plan.md, and get explicit user confirmation before any
-  implementation starts.
+  Draft a structured plan in issue<N>_plan.md and get explicit user
+  confirmation before any implementation starts.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue plan (`/iflow-plan`)
 
-Follow this skill when the user wants to **design the approach** for an issue before touching code.
-
-## When to use
-
-- The user runs `/iflow-plan`, mentions **issue-plan**, or asks you to design the approach / write a plan for the current issue.
-- You want a clear, confirmed plan before `/iflow-start` begins editing code.
+Follow this skill to **design the approach** for the focus issue before touching code, and to get the plan confirmed ahead of `/iflow-start`.
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow-start/SKILL.md
+++ b/.cursor/skills/iflow-start/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: iflow-start
 description: >-
-  Run the /iflow-start workflow: pick the current issue, read issue<N>_plan.md
-  (offer to run /iflow-plan if missing), then implement with the project's
-  documented conventions (e.g. uv run, or inside an activated conda env).
+  Implement the confirmed plan for the focus issue using the project's
+  documented conventions.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue start (`/iflow-start`)
 
-Follow this skill when the user wants to **begin implementation** from issue notes and project rules. Planning itself lives in `/iflow-plan`; this skill is now implementation-only.
-
-## When to use
-
-- The user runs `/iflow-start`, mentions **issue-start**, or asks to implement from `.issueflows/01-current-issues/`.
-- Work should follow the issue-flow markdown workflow and stay aligned with `.cursor/rules/issueflow-rules.mdc` when present.
+Follow this skill to **begin implementation** from issue notes and project rules. Planning itself lives in `/iflow-plan`; this skill is implementation-only. Stay aligned with `.cursor/rules/issueflow-rules.mdc` when present.
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow-status/SKILL.md
+++ b/.cursor/skills/iflow-status/SKILL.md
@@ -1,22 +1,13 @@
 ---
 name: iflow-status
 description: >-
-  Run the /iflow-status report: a read-only snapshot of where every issue stands
-  — local issue-flow tracking state under .issueflows/ (focus / parked /
-  solved) plus open GitHub issues cross-referenced against the local folders.
-  Off-path: never auto-dispatched by /iflow. Writes nothing.
+  Read-only snapshot of where every issue stands, locally and on GitHub.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue status overview (`/iflow-status`)
 
-Follow this skill when the user wants a bird's-eye view of every issue's status
-rather than acting on the single focus issue.
-
-## When to use
-
-- The user runs `/iflow-status`, mentions "status of issues", "what's the state of all issues", "where do things stand", or asks for an issue overview / dashboard.
-- You want to see parked work, the focus issue's lifecycle stage, and open GitHub issues in one place.
+Follow this skill for a bird's-eye view of every issue's status — local tracking state (focus / parked / solved) plus open GitHub issues — rather than acting on the single focus issue.
 
 Do **not** use this skill to *change* anything. It is read-only and off-path; for acting on the focus issue use `/iflow`, and to choose the next issue use `/iflow-pick`.
 

--- a/.cursor/skills/iflow-version-bump/SKILL.md
+++ b/.cursor/skills/iflow-version-bump/SKILL.md
@@ -1,20 +1,14 @@
 ---
 name: iflow-version-bump
 description: >-
-  Bump the project version in pyproject.toml using uv. Supports every uv bump
-  level (major, minor, patch, stable, alpha, beta, rc, post, dev) and a
-  pre-release-aware default when no level is given. Runs from the project root.
+  Bump the project version in pyproject.toml using uv, with a
+  pre-release-aware default when no level is given.
 disable-model-invocation: true
 ---
 
 # issue-flow — version bump
 
-Use when the user wants to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`).
-
-## When to use
-
-- The user asks for a version bump — either a specific level, or just "bump" / "release" with no level (use the default rule below).
-- The repo is a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field (standard for packages using issue-flow).
+Use this skill to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`) — either at a specific level, or with the default rule below when none is given. It targets a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field.
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow-yolo/SKILL.md
+++ b/.cursor/skills/iflow-yolo/SKILL.md
@@ -1,23 +1,16 @@
 ---
 name: iflow-yolo
 description: >-
-  Run the /iflow-yolo workflow: preflight (no default branch, clean tree,
-  passing tests), single consolidated confirm, then chain init → plan → start
-  → close yolo (hands-off close: auto changelog, PR merge, default-branch
-  pull) for small, low-risk issues. Stops on any ambiguity.
+  Chain init → plan → start → close yolo for a small, low-risk issue under
+  one consolidated confirm. Stops on any ambiguity.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue yolo (`/iflow-yolo`)
 
-Follow this skill when the user wants to **blast through a small, low-risk issue** in one shot.
+Follow this skill to **blast through a small, low-risk issue** in one shot, with no mid-run confirmation checkpoints beyond the single consolidated confirm.
 
 Use only for minor fixes, doc tweaks, and similar low-risk changes. Anything non-trivial should go through the individual commands.
-
-## When to use
-
-- The user runs `/iflow-yolo`, `/issue-fast`, mentions **issue-yolo**, or asks to "just do it" for a small issue.
-- The task is obviously small and the user has accepted that there will be no mid-run confirmation checkpoints.
 
 
 ### MODEL & EXECUTION DIRECTIVE

--- a/.cursor/skills/iflow/SKILL.md
+++ b/.cursor/skills/iflow/SKILL.md
@@ -1,22 +1,14 @@
 ---
 name: iflow
 description: >-
-  Run the /iflow smart dispatcher: detect where the focus issue stands in the
-  lifecycle (via files in .issueflows/01-current-issues/ and
-  status markers) and dispatch to /iflow-init, /iflow-plan, /iflow-start, or
-  /iflow-close. Forwards trailing args verbatim. Never auto-dispatches to
-  /iflow-pause, /iflow-cleanup, or /iflow-yolo.
+  Smart dispatcher: detect where the focus issue stands and dispatch to
+  /iflow-init, /iflow-plan, /iflow-start, or /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — iflow smart dispatcher (`/iflow`)
 
-Follow this skill when the user wants to run **the right next step** in the issue-flow lifecycle without remembering which specific command applies.
-
-## When to use
-
-- The user runs `/iflow`, mentions **iflow**, or asks "what's the next step?" during an issue-flow lifecycle.
-- You want a single entry point that routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close` based on current state.
+Follow this skill to run **the right next step** in the issue-flow lifecycle: it detects state and routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close`, forwarding trailing args verbatim.
 
 Do **not** use this skill for `/iflow-pick`, `/iflow-pause`, `/iflow-cleanup`, `/iflow-yolo`, or `/iflow-fix`. Those are explicit-only commands. (`/iflow-pick` is the front door *before* `/iflow-init`, for when no issue has been chosen yet. `/iflow-fix` runs an interactive iterative-fixes session, driven by `/iflow-fix` + `/iflow-close`.)
 

--- a/.cursor/skills/writing-great-skills/GLOSSARY.md
+++ b/.cursor/skills/writing-great-skills/GLOSSARY.md
@@ -1,0 +1,203 @@
+<!--
+Vendored from https://github.com/mattpocock/skills
+(skills/productivity/writing-great-skills), commit d11147d, fetched 2026-07-06.
+Upstream license: MIT. Copyright (c) Matt Pocock.
+Kept verbatim as a reference for editing issue-flow skill templates; see
+.issueflows/04-designs-and-guides/skill-authoring.md for the house rules.
+-->
+
+# Glossary — Building Great Skills
+
+The domain model for what makes a skill great. A skill exists to wrangle determinism out of a stochastic system; the root virtue is **Predictability**, and every term below is a lever on it. This is the disclosed reference for [`writing-great-skills`](SKILL.md).
+
+The terms are grouped by axis: **Invocation** (how a skill is reached), **Information Hierarchy** (how its content is arranged), **Steering** (how the agent's runtime behaviour is shaped), and **Pruning** (how it is kept lean). Each **failure mode** lives beside the lever that cures it, tagged _failure mode_.
+
+**Bold terms** in any definition are themselves defined in this glossary; find them by their heading.
+
+## Predictability
+
+The degree to which a skill makes the agent behave the same _way_ on every run — the same process, not the same output (a brainstorming skill should _predictably_ diverge; its tokens vary, its behaviour doesn't). The root virtue every other term serves — cost and maintainability are symptoms of it, not rivals.
+
+_Avoid_: consistency, reliability, robustness, output-determinism
+
+## Invocation
+
+How a skill is reached — and the two loads you pay for the choice.
+
+### Model-Invoked
+
+A skill that keeps its **description** field, so the agent can see it and fire it autonomously — and the human can still type its name, so model-invocation always _includes_ user reach. There is no model-only state: a description only ever _adds_ agent discovery, never removes the human's. Pays a permanent **context load** on every turn in exchange for that discoverability. Reachable by other skills, because the description that makes it agent-discoverable makes it invocable. A model-invoked skill whose content is all **reference** is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Pick model-invocation only when the agent must reach the skill on its own; if it never fires except by hand, drop the description and pay no context load.
+
+_Avoid_: ability, tool, capability
+
+### User-Invoked
+
+A skill with its **description** stripped — invisible to the agent and reachable only by the human typing its name (user-_only_, where **model-invoked** is user-_and-agent_). Trades agent-discoverability for zero **context load**. Because it has no description, nothing but the human can reach it: no other skill can fire it.
+
+_Avoid_: procedure, workflow, command
+
+### Description
+
+The skill's machine-readable trigger, and the one **context pointer** a **model-invoked** skill is forced to keep loaded at all times. Its mere presence _is_ the invocation axis: keep it and the skill is model-invoked (and reachable by other skills); delete it and the skill is **user-invoked**, reachable only by the human. The source of a model-invoked skill's **context load**.
+
+_Avoid_: frontmatter, summary
+
+### Context Pointer
+
+A reference held in the agent's context that names some out-of-context material and encodes the condition for reaching it. The **description** is the top-level context pointer (context window → skill); pointers to disclosed files are the same object one level down. Its wording, not the target, decides _when_ the agent reaches — and _how reliably_. A must-have target behind a weakly worded pointer is a variance bug: fix the wording first, and inline the material only if sharpening fails.
+
+_Avoid_: link, reference, import
+
+### Context Load
+
+The cost a **model-invoked** skill imposes on the agent's context window — its **description**, always loaded, spending both tokens and attention. What **user-invoked** skills escape by having no description, and the brake on splitting into more model-invoked skills.
+
+_Avoid_: token cost, context bloat
+
+### Cognitive Load
+
+The cost a **user-invoked** skill imposes on the human — what they must hold in their head: which skills exist and when to reach for each (the human is the index). What **model-invocation** removes by being agent-discoverable, and the brake on splitting into more user-invoked skills. Not a cost to minimise: it is the price of human agency, the reason some skills stay user-invoked. Spend it where human judgement matters; remove it where it does not.
+
+_Avoid_: human index, burden, overhead
+
+### Router Skill
+
+A **user-invoked** skill whose job is to point at your other user-invoked skills — naming each and when to reach for it — so the human has one skill to remember instead of many. It can only hint, never fire them: user-invoked skills have no **description**, so nothing but the human can reach them. The cure for **cognitive load** when user-invoked skills multiply.
+
+_Avoid_: dispatcher, menu, registry, index, router procedure
+
+### Granularity
+
+How finely you divide skills. Finer division spends one of the two loads: more **model-invoked** skills spend **context load** (more descriptions crowding the window and competing for attention); more **user-invoked** skills spend **cognitive load** (more for the human to remember and reach for). Two cuts guide the division. By **invocation**, split off a model-invoked skill where you have a distinct **leading word** to trigger it — a trigger word you actually use in your prompts. By **sequence**, split a run of **steps** where a step's **post-completion steps** need hiding, since isolating it in its own context clears what follows. Beware the reverse: merging sequences exposes each step's post-completion steps to what follows, inviting premature completion.
+
+_Avoid_: chunking, modularity
+
+## Information Hierarchy
+
+How a skill's content is arranged, and how far down the ladder each piece sits.
+
+### Information Hierarchy
+
+A skill's content ranked by how immediately the agent needs it — a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
+
+- **Steps** — in-file, primary
+- **Reference**, in-file — secondary
+- **Reference**, disclosed — behind a **context pointer**
+
+A skill with no **steps** uses just the bottom two rungs — often a legitimately flat peer-set (e.g. every rule of a review on one rung), which is a fine arrangement, not a smell. The hierarchy is independent of invocation: a skill can be model- or user-invoked whether it is all steps, all reference, or both. When a skill has steps, in-file reference that should be disclosed buries them and turns attending to them into a coin-flip — a variance lever, not just a legibility one. Keep the top of the ladder legible; push down it whatever you can.
+
+_Avoid_: structure, organization, layout
+
+### Steps
+
+The ordered actions the agent performs — when a skill has them, the primary tier of its content, and the part that earns its place in SKILL.md. Not every skill has steps: a skill can be all steps (`tdd`), all **reference** (a review), or both, independent of invocation. Every step ends on a **completion criterion**, clear or vague.
+
+_Avoid_: workflow, instructions, choreography
+
+### Reference
+
+Material the agent refers to on demand — definitions, facts, parameters, examples, conditional instructions. When a skill has **steps** it is secondary to them; when a skill has none it is the entire content; or it lives outside any skill entirely — see **External Reference**. Reached via **context pointers**, and the prime candidate for **progressive disclosure**.
+
+_Avoid_: supporting material, docs, background
+
+### External Reference
+
+**Reference** that lives outside the skill system — a plain file, no **description**, no **steps**, not invocable — that any skill can point at. The home for shared reference that needn't fire on its own, and the only shared home two **user-invoked** skills can use, since neither has a description and so neither can fire the other.
+
+_Avoid_: doc, resource, knowledge base
+
+### Progressive Disclosure
+
+Moving **reference** down the ladder — out of SKILL.md and behind a **context pointer** — so the top stays legible. Not primarily a token optimisation; it is how the **information hierarchy** is protected. Licensed by **branching**: disclose what only some branches need, inline what every path needs, and if a pointer fires unreliably on must-have material, sharpen its wording, and pull it back inline only if that fails.
+
+_Avoid_: lazy loading, chunking
+
+### Co-location
+
+Keeping the material an agent needs at once in one place — a concept's definition, rules, and caveats under a single heading, not scattered across the file — so reading one part brings its neighbours with it. The within-file companion to the **Information Hierarchy**: the hierarchy ranks _how far down_ a piece sits; co-location decides _what sits beside it_ once there. There is no formula for the right format of a body of **reference**; the test is that a skill should read like documentation written for the agent, and grouped material reads that way where scattered material does not. Distinct from **Duplication**: that repeats one meaning in two places, where scattering fragments a single meaning across many.
+
+_Avoid_: grouping, clustering, cohesion
+
+### Sprawl
+
+_Failure mode._ A skill that is simply too long — too many lines in SKILL.md — independent of whether they are stale or repeated. Even an all-live, all-unique skill can sprawl. It costs readability (the agent wades through more before it can act, and attention thins across the excess), maintainability (every extra line is one more to keep **relevant**), and tokens. The cure is the **information hierarchy**: push **reference** down behind **context pointers**, and split by **branch** or sequence so each path carries only what it needs. Distinct from **sediment** (length from stale accumulation) and **duplication** (length from repeated meaning) — sprawl is length itself, whatever its cause.
+
+_Avoid_: bloat, length, size, verbosity
+
+## Steering
+
+The levers that shape the agent's runtime behaviour toward **Predictability**.
+
+### Branch
+
+A distinct way a skill can be invoked — a case the skill handles — so different runs take different paths through it. A skill with many steps may carry many branches; a linear one has none.
+
+_Avoid_: path, case, fork
+
+### Leading Word
+
+A compact concept — also called a _Leitwort_ — already living in the model's pretraining, that the agent thinks with while running the skill. It encodes a behavioural principle in the fewest possible tokens by invoking priors the model already holds (e.g. _lesson_, _proximal zone of development_, _fog of war_, _tracer bullets_). Repeated as a token, never as a sentence, it accumulates a distributed definition across the skill and anchors a whole region of behaviour. Coining your own works if you define it clearly, but a made-up word recruits no priors — you pay in definition tokens what a pretrained word gives free. Reach for an existing word first.
+
+A leading word serves **predictability** twice. In the body it anchors **execution** — the agent reaches for the same behaviour every time the concept appears, and inside flat reference it focuses attention on a class of thing to look for, recruiting the right checks each run. In the **description** it anchors **invocation** — and not only within the skill: when the same word lives in your prompts, your docs, and your codebase, the agent links that shared language to the skill and fires it more reliably. Word a description with the leading words you actually use when you want the skill.
+
+_Avoid_: keyword, term, motif
+
+### Completion Criterion
+
+The condition that tells the agent a unit of work is done — the target it judges against. Two properties make it a lever, not just a quality. Its **clarity** (can the agent tell done from not-done?) resists **premature completion** — a vague bound ("understanding reached") lets the agent declare done and slip to the next step; this axis needs _steps_ to bite, since premature completion is a between-steps failure. Its **demand** (how much it requires) sets **legwork** — "every modified model accounted for" forces thorough work where "produce a change list" does not — and this axis is _not_ step-bound: it can bind a body of flat reference too, which is how a skill with no steps still carries an exhaustiveness bar ("every rule applied"). The strongest criteria are both checkable and exhaustive.
+
+_Avoid_: done condition, exit condition, stopping rule
+
+### Legwork
+
+The work an agent does behind the scenes within a single step — reading files, exploring the codebase, making changes, digging up what it needs rather than offloading to the user. It lives below the step structure: never written as its own step, latent in the wording, controlled by the agent rather than the skill. The within-step counterpart to **post-completion steps**' across-step pull. Raised by a **leading word** (_comprehensive_, _thorough_) or a **completion criterion** that demands the work be exhaustive — including the demand axis applied to flat reference, which is what drives a skill of flat reference to cover all its rungs. Goes thin either when that demand is missing or when **premature completion** cuts the step short.
+
+_Avoid_: scope, effort, diligence, coverage
+
+### Post-Completion Steps
+
+The **steps** that follow the current step. Visible, they pull the agent forward into **premature completion** — the more it sees, the stronger the tug; the defence is to hide them by splitting the sequence of steps into two.
+
+_Avoid_: horizon, fog of war, lookahead
+
+### Premature Completion
+
+_Failure mode._ Ending the current step before it is genuinely done, because the agent's attention slips to being done rather than to the work. A between-steps failure: it needs **steps** to occur — a skill with no steps that quits early isn't premature completion but thin **legwork** under an unmet demand. A tug-of-war between two forces: visible **post-completion steps** (the pull forward) and the **completion criterion**'s clarity (the resistance — a sharp, checkable bar holds; a vague one gives way). Fuzziness is the necessary condition: a sharp bound resists the pull no matter how many later steps are visible, so a step that never rushes needs no defending. Two levers hold a step that does, but reach for them in order: **sharpen the bound first** — it is local and cheap. Only when the criterion is irreducibly fuzzy _and_ you actually observe the rush do you **hide the later steps** — and hiding only works across a real context boundary (a user-invoked hand-off or a subagent dispatch; an inline model-invoked call leaves the later steps in context and clears nothing). One cause of thin legwork, but distinct from it: legwork can be thin even when a step runs to full completion.
+
+_Avoid_: premature closure, the rush, rushing, shortcutting
+
+## Pruning
+
+Keeping a skill lean — each remedy paired with the failure it cures.
+
+### Single Source of Truth
+
+The desired state where each meaning lives in exactly one authoritative place, so a change to the skill's behaviour is a change in one place. **Duplication** is its violation.
+
+_Avoid_: home, canonical location
+
+### Duplication
+
+_Failure mode._ The same meaning given more than one **single source of truth**. It costs maintenance (change one place, you must change the others), costs tokens, and inflates prominence — repeating a meaning weights it on the ladder past its real rank. The accidental inverse of a **leading word**, which raises attention on purpose by repeating a token, never the meaning.
+
+_Avoid_: repetition, redundancy
+
+### Relevance
+
+Whether a line still bears on what the skill does — the lens for what to keep. A line loses relevance either by never bearing on the task (mere exposition, or a **branch** that should be disclosed) or by going stale: drifting out of date as the behaviour or world it describes changes. Shorter skills are easier to keep relevant, because each line is cheaper to check. Distinct from **no-op**: relevance asks whether a line bears on the task, not whether it changes behaviour.
+
+_Avoid_: load-bearing, staleness, freshness
+
+### Sediment
+
+_Failure mode._ Layers of old content that settle in a skill and are never cleared, because adding feels safe and removing feels risky — so stale and irrelevant lines accumulate and you must core down through them to find what is still live. The default fate of any skill without a pruning discipline; the slow erosion of **relevance**, as opposed to **duplication**'s repeated meaning.
+
+_Avoid_: accretion, bloat, cruft, rot
+
+### No-Op
+
+_Failure mode._ An instruction that changes nothing because the model already does it by default — you pay load to tell the agent what it would do anyway. The test: does a line change behaviour versus the default? A line can be perfectly **relevant** and still be a no-op. The same priors that make a **leading word** free make a no-op worthless.
+
+A leading word is a _technique_; No-Op is a _verdict_ on a line — and they cross. A leading word too weak to beat the default is a no-op (_be thorough_ when the agent is already thorough-ish), and the fix is a stronger word that passes the verdict (_relentless_), not a different technique. So the No-Op test — does it change behaviour versus the default? — is also how you grade whether a leading word is earning its repetitions. This is model-relative, not reader-relative: two people disagreeing over whether a line is a no-op disagree about the default, and settle it by running the skill, not by debate.
+
+_Avoid_: redundant instruction, restating the obvious, belaboring

--- a/.cursor/skills/writing-great-skills/SKILL.md
+++ b/.cursor/skills/writing-great-skills/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: writing-great-skills
+description: Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable.
+disable-model-invocation: true
+---
+
+<!--
+Vendored from https://github.com/mattpocock/skills
+(skills/productivity/writing-great-skills), commit d11147d, fetched 2026-07-06.
+Upstream license: MIT. Copyright (c) Matt Pocock.
+Kept verbatim as a reference for editing issue-flow skill templates; see
+.issueflows/04-designs-and-guides/skill-authoring.md for the house rules.
+-->
+
+A skill exists to wrangle determinism out of a stochastic system. **Predictability** — the agent taking the same _process_ every run, not producing the same output — is the root virtue; every lever below serves it.
+
+**Bold terms** are defined in [`GLOSSARY.md`](GLOSSARY.md); look them up there for the full meaning.
+
+## Invocation
+
+Two choices, trading different costs:
+
+- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
+- A **user-invoked** skill strips the description from the agent's reach: only you, typing its name, can invoke it — and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
+
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each.
+
+## Writing the description
+
+A model-invoked **description** does two jobs — state what the skill is, and list the **branches** that should trigger it. Every word increases **context load**, so a description earns even harder pruning than the body:
+
+- **Front-load the skill's leading word** — the description is where it does its invocation work.
+- **One trigger per branch.** Synonyms that rename a single branch are **duplication** — "build features using TDD … asks for test-first development" is one branch written twice. Collapse them; keep only genuinely distinct branches.
+- **Cut identity that's already in the body.** Keep the description to triggers, plus any "when another skill needs…" reach clause.
+
+## Information hierarchy
+
+A skill is built from two content types — **steps** and **reference** — that mix freely: a skill can be all steps, all reference, or both. The core decision is which to use and where each sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-skill step** — an ordered action in `SKILL.md`, the primary tier: what the agent does, in order. Each step ends on a **completion criterion**, the condition that tells the agent the work is done. Make it _checkable_ (can the agent tell done from not-done?) and, where it matters, _exhaustive_ ("every modified model accounted for", not "produce a change list") — a vague criterion invites **premature completion**.
+2. **In-skill reference** — a definition, rule, or fact in `SKILL.md`, consulted on demand. Often a legitimately flat peer-set (every rule of a review on one rung) — a fine arrangement, not a smell. _This skill is all reference._
+3. **External reference** — reference pushed out of `SKILL.md` into a separate file, reached by a **context pointer**, loaded only when the pointer fires. (Spans _disclosed_ reference — a sibling file like `GLOSSARY.md`, still part of the skill — through fully **external reference** that lives outside the skill system and any skill can point at.)
+
+A demanding completion criterion drives thorough **legwork** — the digging the agent does within the work — whether the skill has steps or not, since "every rule applied" binds flat reference just as "every step done" binds a sequence.
+
+Push too little down and the top bloats; push too much and you hide material the agent actually needs. That tension is the whole decision.
+
+**Progressive disclosure** is the move down the ladder — out of `SKILL.md` into a linked file — so the top stays legible. Mechanics: a linked `.md` file in the skill folder, named for what it holds (this skill discloses its full definitions to `GLOSSARY.md`). Some skills are used in more than one way, and each distinct way is a **branch** — different runs taking different paths through the skill. Branching is the cleanest disclosure test: inline what every branch needs, and push behind a pointer what only some branches reach. A **context pointer**'s _wording_, not its target, decides when and how reliably the agent reaches the material.
+
+Where the ladder decides _how far down_ a piece sits, **co-location** decides _what sits beside it_ once there: keep a concept's definition, rules, and caveats under one heading rather than scattered, so reading one part brings its neighbours with it.
+
+## When to split
+
+**Granularity** is how finely you divide skills, and each cut spends one of the two loads, so split only when the cut earns it. Two cuts:
+
+- **By invocation** — split off a **model-invoked** skill when you have a distinct **leading word** that should trigger it on its own, or another skill must reach it. You pay **context load** for the new always-loaded **description**, so that independent reach has to be worth it.
+- **By sequence** — split a run of **steps** when the steps still ahead (a step's **post-completion steps**) tempt the agent to rush the one in front of it (**premature completion**). Keeping them out of view encourages the agent to do more **legwork** on the current task.
+
+## Pruning
+
+Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit.
+
+Check every line for **relevance**: does it still bear on what the skill does?
+
+Then hunt **no-ops** sentence by sentence, not just line by line: run the no-op test on each sentence in isolation, and when one fails, delete the whole sentence rather than trim words from it. Be aggressive — most prose that fails should go, not be rewritten.
+
+## Leading words
+
+A **leading word** is a compact concept already living in the model's pretraining that the agent thinks with while running the skill (e.g. _lesson_, _fog of war_, _tracer bullets_). Repeated throughout the text (though not necessarily - a strong leading word might only be needed once), it accumulates a distributed definition and anchors a whole region of behaviour in the fewest tokens, by recruiting priors the model already holds.
+
+It serves predictability twice. In the body it anchors _execution_: the agent reaches for the same behaviour every time the word appears. In the description it anchors _invocation_: when the same word lives in your prompts, docs, and code, the agent links that shared language to the skill and fires it more reliably.
+
+Hunt for opportunities to refactor skills to use leading words. A triad spelled out at three sites (**duplication**), a description spending a sentence to gesture at one idea — each is a passage begging to **collapse** into a single token. Examples include:
+
+- "fast, deterministic, low-overhead" -> _tight_ — one quality restated across a phase — into a single pretrained word (a _tight_ loop).
+- "a loop you believe in" -> _red_ — converts a fuzzy gate into a binary observable state (the loop goes _red_ on the bug, or it doesn't).
+
+You win twice over: fewer tokens, _and_ a sharper hook for the agent to hang its thinking on. Assume every skill is carrying restatements that leading words retire — go find them.
+
+## Failure modes
+
+Use these to diagnose issues the user may be having with the skill.
+
+- **Premature completion** — ending a step before it's genuinely done, attention slipping to _being done_. Defence, in order: sharpen the completion criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the post-completion steps by splitting (the sequence cut).
+- **Duplication** — the same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning's prominence on the ladder past its real rank.
+- **Sediment** — stale layers that settle because adding feels safe and removing feels risky. The default fate of any skill without a pruning discipline.
+- **Sprawl** — a skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the ladder: disclose **reference** behind pointers, and split by **branch** or sequence so each path carries only what it needs.
+- **No-op** — a line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak leading word (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.

--- a/.issueflows/01-current-issues/issue117_original.md
+++ b/.issueflows/01-current-issues/issue117_original.md
@@ -1,0 +1,11 @@
+# Issue #117: great skills
+
+Source: https://github.com/jepegit/issue-flow/issues/117
+
+## Original issue text
+
+mattpocok has created a skill for writing great skills. https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills
+
+We should add this to our issue-flow repository as a reference so that we can follow his best practices.
+
+Go through the skills issue-flow creates and check and update skills that are not good.

--- a/.issueflows/01-current-issues/issue117_plan.md
+++ b/.issueflows/01-current-issues/issue117_plan.md
@@ -1,0 +1,57 @@
+# Issue #117 plan: great skills
+
+Source issue: [issue117_original.md](issue117_original.md)
+
+## Goal
+
+Vendor mattpocock's [writing-great-skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills) skill into this repo as a reference, then audit and update the skill templates issue-flow ships so they follow its best practices.
+
+## Constraints
+
+- **Templates are the source of truth** — edit `src/issue_flow/templates/skills/*/SKILL.md.j2`, never the rendered copies under `.cursor/skills/`; re-render via `issue-flow update` afterwards (per `AGENTS.md` and `this-project.md`).
+- **Behavior-preserving** — pruning/conformance only. All workflow semantics (confirmations, off-path markers, `- [x] Done` rules, file-movement rules, output contracts) must survive in meaning. No lifecycle changes.
+- Upstream repo is **MIT-licensed** — vendor with attribution header (source URL + license note).
+- Jinja2 variables (`{{ issueflows_dir }}` etc.) and the `_model_directive.md.j2` include must keep rendering; verify with the scaffold checker.
+
+### Prior art
+
+- `.issueflows/00-tools/verify_scaffold.py` — end-to-end scaffold render check; reuse it, don't write a new checker.
+- `.issueflows/04-designs-and-guides/caveman-skill.md`, `grill-me-skill.md` — existing pattern of per-skill design docs; a new `skill-authoring.md` guide follows the same convention.
+- `src/issue_flow/templates/skills/_model_directive.md.j2` — shared include; conformance edits must keep it.
+
+## Approach
+
+1. **Vendor the reference** into `.cursor/skills/writing-great-skills/` (`SKILL.md` + `GLOSSARY.md`, faithful copies with a short attribution header: source URL, fetch date, MIT). User-invoked (`disable-model-invocation: true`) — zero context load; it is a reference we reach for when editing skill templates. This folder is not touched by `issue-flow update` (only its own managed skills are rewritten).
+2. **Add a terse authoring guide** `.issueflows/04-designs-and-guides/skill-authoring.md`: the decision (we follow the vendored reference), house rules distilled for issue-flow templates (user-invoked skills get one-line human-facing descriptions; model-invoked skills — caveman, grill-me — keep trigger-rich descriptions; shared material goes behind pointers like `iflow-comments`; no-op/sediment pruning discipline), link back to issue #117.
+3. **Audit all 18 skill templates** against the reference and fix conformance issues. Known findings to fix:
+   - **Descriptions on user-invoked skills** — every `iflow-*` skill sets `disable-model-invocation: true` yet carries a multi-line trigger-rich description. Per the reference, a user-invoked description is a one-line human-facing summary; trim all of them.
+   - **"When to use" trigger lists in user-invoked skills** — partly no-op (only the human invokes); keep genuinely behavior-bearing lines (e.g. "do not use from /iflow"), drop trigger phrasing.
+   - **Duplication** — `iflow_init` inlines a "Summary of rules" copy of `iflow_comments`' triage rules; collapse to the context pointer. Hunt equivalents elsewhere.
+   - **No-ops / sediment** — sentence-level pass over each template ("Use UTF-8 for markdown output", restated defaults, stale lines).
+   - **Completion criteria** — sharpen vague step ends where cheap and safe.
+4. **Re-render this repo's own scaffold** (`issue-flow update` dogfood) so `.cursor/skills/` and `.cursor/commands/` match the new templates.
+5. **Note, don't fix**: `templates/commands/*.md.j2` duplicate skill content wholesale (~1070 lines) — a single-source-of-truth violation, but restructuring the command/skill split is its own issue (see Open questions).
+
+Order: 1 → 2 → 3 (worst offenders first: `iflow_comments`, `iflow_history_update`, `iflow_init`) → 4 → tests.
+
+## Files to touch
+
+- `.cursor/skills/writing-great-skills/SKILL.md`, `GLOSSARY.md` — new, vendored with attribution.
+- `.issueflows/04-designs-and-guides/skill-authoring.md` — new, terse house rules + pointer.
+- `src/issue_flow/templates/skills/*/SKILL.md.j2` — 18 files, conformance edits (descriptions, trigger-list pruning, duplication collapse, no-op removal).
+- `.cursor/skills/*/SKILL.md`, `.cursor/commands/*` — re-rendered by `issue-flow update` (mechanical).
+- `tests/` — update any assertions pinned to old description text (check first).
+
+## Test strategy
+
+- `uv run pytest` — full suite.
+- `uv run ruff check src/ tests/` — lint.
+- `uv run .issueflows/00-tools/verify_scaffold.py` — end-to-end scaffold render + marker checks (label-driven yolo routing, hands-off close markers must survive).
+- Grep rendered output for load-bearing markers (`disable-model-invocation`, off-path notes, `- [x] Done`) after re-render.
+
+## Open questions
+
+1. **Command/skill duplication** — recommend filing a follow-up issue ("commands should be thin pointers to skills, or generated from them") instead of folding it into this PR. Confirm?
+2. **Vendored copy location** — recommend `.cursor/skills/writing-great-skills/` (agent-reachable while editing templates) over a plain doc in `04-designs-and-guides/`. Confirm?
+3. **Scaffold the reference into target projects too?** Issue says "our issue-flow repository", so recommend **no** — repo-local only, not a new template. Confirm?
+4. **Audit depth** — recommend full behavior-preserving pruning pass per skill (not just descriptions). Confirm?

--- a/.issueflows/01-current-issues/issue117_status.md
+++ b/.issueflows/01-current-issues/issue117_status.md
@@ -1,0 +1,26 @@
+# Issue #117 status: great skills
+
+- [x] Done
+
+## What's done
+
+- Vendored mattpocock's `writing-great-skills` reference (SKILL.md + GLOSSARY.md, MIT, upstream commit `d11147d`) into `.cursor/skills/writing-great-skills/` with an attribution header.
+- Added `.issueflows/04-designs-and-guides/skill-authoring.md` — the decision to follow the reference plus house rules distilled for issue-flow templates.
+- Audited all 18 skill templates under `src/issue_flow/templates/skills/` against the reference and applied behavior-preserving conformance edits:
+  - Trimmed every user-invoked (`disable-model-invocation: true`) skill's description to a one-line human-facing summary (trigger lists belong only to model-invoked skills).
+  - Removed "When to use" trigger sections from user-invoked skills, keeping behavior-bearing lines (off-path / do-not-use-from rules) in the intro; only model-invoked `grill-me` keeps its trigger section.
+  - Collapsed duplication: `iflow_init`'s inline copy of the `iflow_comments` triage rules is now a pointer; `iflow_close`'s restated version-bump level table defers to `iflow-version-bump`; caveman's Intensity section no longer repeats its Rules; `iflow_history_update`'s `nohistory` rule now lives in one place.
+  - Pruned no-ops/sediment ("Use UTF-8", stale `--bump <patch|minor|major>` level list in close).
+  - Fixed a structural defect: `iflow_pick` was missing its `### Phase 2 — create the branch` heading.
+- Re-rendered this repo's own scaffold via `issue-flow update` (18 skills + rule + doc).
+
+## Testing
+
+- `uv run pytest` — 331 passed.
+- `uv run ruff check src/ tests/` — clean.
+- `uv run .issueflows/00-tools/verify_scaffold.py` — all checks passed (label routing, hands-off close markers, config flips).
+- Fresh end-to-end scaffold into a throwaway project confirmed the new descriptions render and only `grill-me` keeps a "When to use" section.
+
+## Remaining work
+
+- None for this issue. Follow-up candidate (not filed): `templates/commands/*.md.j2` duplicate skill content wholesale (~1070 lines) — single-source-of-truth violation, tracked in `skill-authoring.md` under "Known debt".

--- a/.issueflows/04-designs-and-guides/skill-authoring.md
+++ b/.issueflows/04-designs-and-guides/skill-authoring.md
@@ -1,0 +1,51 @@
+# Skill authoring — house rules
+
+Context: issue [#117](https://github.com/jepegit/issue-flow/issues/117). We adopted
+mattpocock's **writing-great-skills** reference (vendored verbatim, MIT, at
+`.cursor/skills/writing-great-skills/` — `SKILL.md` + `GLOSSARY.md`) as the
+standard for every skill issue-flow ships. Read it before editing any template
+under `src/issue_flow/templates/skills/`.
+
+## Decision
+
+All shipped skills follow the vendored reference. Templates are the single
+source of truth; edit `SKILL.md.j2`, then re-render with `issue-flow update`.
+
+## House rules (distilled for issue-flow templates)
+
+- **Invocation.** Lifecycle skills (`iflow-*`) are **user-invoked**
+  (`disable-model-invocation: true`): their `description` is a one-line,
+  human-facing summary — no trigger lists ("Use when the user mentions…"),
+  those belong only to model-invoked skills. Only `caveman` and `grill-me`
+  are model-invoked and keep trigger-rich descriptions.
+- **No trigger-bait "When to use" sections in user-invoked skills.** Keep
+  genuinely behavior-bearing lines (e.g. "off-path: never auto-dispatch from
+  /iflow"); drop lines that only restate invocation triggers.
+- **Single source of truth.** Shared material lives in one place and is
+  reached by a context pointer (e.g. `iflow-init` points at `iflow-comments`
+  instead of inlining a rules summary).
+- **Prune no-ops and sediment.** Sentence-level test: does the line change
+  behavior versus the model's default? If not, delete the sentence (e.g.
+  "Use UTF-8 for markdown output").
+- **Sharpen completion criteria.** Prefer checkable, exhaustive bounds
+  ("every group moved and reported") over vague ones ("handle the folder").
+- **Behavior is sacred.** Pruning must preserve workflow semantics:
+  confirmations, off-path markers, `- [x] Done` rules, file-movement rules,
+  output contracts.
+- **Jinja stays intact.** Keep `{{ issueflows_dir }}`-style variables and the
+  `_model_directive.md.j2` include; verify rendering with
+  `uv run .issueflows/00-tools/verify_scaffold.py`.
+
+## Alternatives considered
+
+- Scaffolding the reference into target projects: rejected — it guides
+  maintainers of this repo, not users of scaffolded projects.
+- Plain doc under `04-designs-and-guides/` instead of a vendored skill:
+  rejected — placing it under `.cursor/skills/` keeps it reachable while an
+  agent edits skill templates, at zero context load (user-invoked).
+
+## Known debt
+
+- `templates/commands/*.md.j2` duplicate skill content wholesale (~1070
+  lines) — a single-source-of-truth violation. Tracked as a follow-up issue
+  candidate; do not fold command restructuring into unrelated PRs.

--- a/src/issue_flow/templates/skills/caveman/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/caveman/SKILL.md.j2
@@ -31,7 +31,7 @@ English only. Caveman applies to English output; do not garble other languages.
 
 ## Intensity
 
-Single level: **full**. Drop articles, fragments OK, short synonyms. Classic caveman. No tool-call narration, no decorative tables/emoji, no long raw error-log dumps unless asked. Standard acronyms OK; no invented abbreviations.
+Single level: **full**. Classic caveman — every rule above applies at full strength; there is no milder setting.
 
 Example — "Why React component re-render?"
 - "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."

--- a/src/issue_flow/templates/skills/iflow_archive/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_archive/SKILL.md.j2
@@ -1,25 +1,19 @@
 ---
 name: iflow-archive
 description: >-
-  Run the /iflow-archive workflow: condense selected solved issue groups under
-  {{ issueflows_dir }}/{{ solved_folder }}/ into a single dated
-  YYYY-MM-DD_archived_issues.md summary file that records the pre-archive git
-  ref for recovery, then delete the original issue<N>_* files. Off-path:
-  never auto-dispatched; destructive, one consolidated confirm.
+  Condense old solved issue groups into one dated summary file, then delete
+  the originals. Destructive, one consolidated confirm.
 disable-model-invocation: true
 ---
 
 # issue-flow — archive solved issues (`/iflow-archive`)
 
-Follow this skill when the user wants to **shrink the solved-issues archive**:
+Follow this skill to **shrink the solved-issues archive**:
 old `issue<N>_*` groups under `{{ issueflows_dir }}/{{ solved_folder }}/` are
 summarised into one dated markdown file and the originals are deleted (they
 stay recoverable through git history).{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-archive.md`.{% endif %}
 
-## When to use
-
-- The user runs `/iflow-archive`, mentions "archive solved issues", "condense the issue archive", or complains the solved folder has grown too big.
-- Do **not** use this to park or close an active issue — that is `/iflow-pause` / `/iflow-close`. This skill only touches `{{ issueflows_dir }}/{{ solved_folder }}/`.
+Do **not** use this to park or close an active issue — that is `/iflow-pause` / `/iflow-close`. This skill only touches `{{ issueflows_dir }}/{{ solved_folder }}/`.
 
 ## Input
 

--- a/src/issue_flow/templates/skills/iflow_cleanup/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_cleanup/SKILL.md.j2
@@ -1,20 +1,14 @@
 ---
 name: iflow-cleanup
 description: >-
-  Run the /iflow-cleanup workflow: detect merge status, switch to the default
-  branch, and — with a single consolidated confirm — delete every local branch
-  already reachable from origin/<default> (including squash-merges). Never -D.
+  Post-merge branch hygiene: switch to the default branch and delete merged
+  local branches under one consolidated confirm. Never -D.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue cleanup (`/iflow-cleanup`)
 
-Follow this skill when the user wants to **run post-merge branch hygiene** after a PR has been merged.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-cleanup.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-cleanup`, mentions **issue-cleanup**, or asks you to delete local branches whose PRs have merged.
-- The PR opened by `/iflow-close` just merged and the user wants the standard post-merge tidy-up.
+Follow this skill to **run post-merge branch hygiene** after a PR has been merged (typically the PR opened by `/iflow-close`).{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-cleanup.md`.{% endif %}
 
 {% include "skills/_model_directive.md.j2" %}
 ## Instructions

--- a/src/issue_flow/templates/skills/iflow_close/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_close/SKILL.md.j2
@@ -1,33 +1,26 @@
 ---
 name: iflow-close
 description: >-
-  Run the /iflow-close workflow: verify tests, optional uv semver bump, update
-  issue status and folder locations, commit, push, and open a PR with a clear
-  summary. Post-merge branch cleanup now lives in /iflow-cleanup.
+  Finish and land the focus issue: tests, optional version bump, status
+  update, commit, push, and PR.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue close (`/iflow-close`)
 
-Follow this skill when the user wants to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-close.md`.{% endif %}
+Follow this skill to **finish and land** work: tests, optional version bump, issue-folder updates, git, and PR.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-close.md`.{% endif %}
 
-Post-merge branch hygiene now lives in `/iflow-cleanup` — this skill no longer deletes branches.
-
-## When to use
-
-- The user runs `/iflow-close`, mentions **issue-close**, or asks to commit, push, or open a PR after issue-flow work.
+Post-merge branch hygiene lives in `/iflow-cleanup` — this skill never deletes branches.
 
 ## Optional version bump (command input)
 
 If the user included text after `/iflow-close` that requests a version bump:
 
-- **`bump`** (no level) → **pre-release-aware default**: stay on the current channel (alpha→`alpha`, beta→`beta`, rc→`rc`, dev→`dev`) or `patch` when the current version is already stable.
-- **A named level** → `uv version --bump <level>` for any uv level: `patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev` (`dev` must be paired, e.g. `--bump patch --bump dev`).
-- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`, "promote to beta" → `beta`); ask once if ambiguous. Never auto-pick `major`.
+- **`bump`** (no level) → apply the pre-release-aware default.
+- **A named level** (`patch`, `minor`, `major`, `stable`, `alpha`, `beta`, `rc`, `post`, `dev`) → use exactly that.
+- Otherwise infer the level from natural language (e.g. "bugfix release" → `patch`); ask once if ambiguous. Never auto-pick `major`.
 
-The exact semantics and the default rule live in `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth.
-
-When a bump applies: read `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md`, run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
+The exact semantics and the default rule live in `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md` — that skill is the source of truth. When a bump applies: read it, then run the bump from the **project root** **after** the sanity check and **before** issue-folder updates and **before** commit / push / PR.
 
 ## Changelog update tokens (command input)
 
@@ -47,7 +40,7 @@ When a bump applies: read `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md`, 
 
 1. **Sanity check** — Run the project test suite (e.g. `uv run pytest`) and any checks the repo relies on. **Ruff (when present):** if the project uses ruff (`[tool.ruff]` in `pyproject.toml`, ruff in dev dependencies, or `{{ issueflows_dir }}/{{ designs_folder }}/python-quality-tools.md` exists), run auto-fix lint through the documented Python runner before committing — e.g. `uv run ruff check --fix …` then `uv run ruff format …` (match paths to what the project documents). Skim the diff; avoid bundling unrelated changes. Confirm that any design decisions or good practices that emerged from this issue are captured under `{{ issueflows_dir }}/{{ designs_folder }}/` before committing.
 
-2. **Optional version bump** — If the user asked for a bump (see above), follow `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <patch|minor|major>`. If there is no bumpable `pyproject.toml`, skip and continue.
+2. **Optional version bump** — If the user asked for a bump (see above), follow `{{ agent_dir }}/skills/iflow-version-bump/SKILL.md` and run `uv version --bump <level>`. If there is no bumpable `pyproject.toml`, skip and continue.
 
 3. **Update `{{ history_file }}`** — Unless the user passed `nohistory`, follow `{{ agent_dir }}/skills/iflow-history-update/SKILL.md`. If step 2 did not bump the version, append a bullet to the `## [Unreleased]` section. If step 2 bumped the version, promote `## [Unreleased]` to `## [<new_version>] - <YYYY-MM-DD>` and open a fresh empty `## [Unreleased]` above it. Show the diff and confirm once before writing. Skip with a note if `{{ history_file }}` does not exist at the project root. With the `yolo` token, do not ask — decide yourself and write the bullet (issue title, or `log "..."` text) directly.
 

--- a/src/issue_flow/templates/skills/iflow_comments/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_comments/SKILL.md.j2
@@ -1,24 +1,16 @@
 ---
 name: iflow-comments
 description: >-
-  Triage a GitHub issue's comment thread into a curated, bucketed summary
-  (additional tasks, clarifications, superseded) for inclusion in
-  issue<N>_original.md. Invoked by /iflow-init; also reusable when re-triaging
-  comments later in an issue's lifecycle.
+  Triage a GitHub issue's comment thread into the curated, bucketed summary
+  section of issue<N>_original.md.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue comments triage
 
-Follow this skill when you need to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `{{ issueflows_dir }}/{{ current_issues_folder }}/issue<N>_original.md`.
+Follow this skill to turn a GitHub issue's comment thread into a short, decision-useful summary that lives next to the original issue body under `{{ issueflows_dir }}/{{ current_issues_folder }}/issue<N>_original.md`.
 
-It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments.
-
-## When to use
-
-- `/iflow-init` just fetched an issue with a non-empty `comments` array and needs to write the `## Comments (curated summary)` section.
-- You are re-running triage on an already-captured issue because new comments have arrived (the issue body text must stay unchanged; only the curated section is rewritten).
-- Any workflow that needs to understand "what does the comment thread actually ask us to do?" without pasting the raw thread into a file.
+It is the playbook that `/iflow-init` (and the `iflow-init` skill) delegate to for anything beyond fetching raw comments. It also covers re-triage of an already-captured issue when new comments arrive (the issue body text stays unchanged; only the curated section is rewritten).
 
 {% include "skills/_model_directive.md.j2" %}
 ## Inputs
@@ -79,7 +71,6 @@ Formatting rules:
 - Each bucket's bullet is itself a list if there is more than one item — nest concrete bullets under the bold label.
 - **Drop any bucket that is empty** — do not leave `- **Additional tasks**: ` with no content.
 - **Always keep the `_Note: ..._` footer** when the section exists. Use the total `comments` length for `<count>` and the `author.login` + date of the most recent non-dropped comment for `@<login>` / `<date>`.
-- Use UTF-8 markdown. No leading/trailing blank lines inside the section beyond what's shown.
 
 ## Edge cases
 
@@ -93,5 +84,4 @@ Formatting rules:
 ## Constraints
 
 - This skill only writes into the `## Comments (curated summary)` section of `issue<N>_original.md`. It never touches the issue body, the status file, or the plan file.
-- It never calls `gh` itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.
-- It never talks to the network beyond what the caller has already fetched.
+- It never calls `gh` or the network itself — it expects the caller (`/iflow-init` or similar) to provide the comments JSON.

--- a/src/issue_flow/templates/skills/iflow_fix/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_fix/SKILL.md.j2
@@ -1,22 +1,14 @@
 ---
 name: iflow-fix
 description: >-
-  Run the /iflow-fix interactive session: set up one long-lived branch + GitHub
-  issue for a stream of small iterative fixes, then loop — each fix gets a short
-  plan, is implemented only on confirmation, and is recorded as a dated bullet in
-  issue<N>_status.md. Finish with /iflow-close. Off-path: never auto-dispatched by
-  /iflow. Always creates a GitHub issue (gh); GitLab is not supported.
+  Interactive session: one long-lived branch + GitHub issue for a stream of
+  small iterative fixes, landed together via /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — interactive iterative-fix session (`/iflow-fix`)
 
-Follow this skill when the user wants an **ongoing working session** for many small fixes on one branch, rather than a single well-defined deliverable.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-fix.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-fix`, mentions "iterative fixes", "small fixes session", or "let's just fix things on a branch".
-- They have a bucket of little improvements (small bugs, typos, chores, polish) to knock out together and land via one PR.
+Follow this skill for an **ongoing working session** of many small fixes (small bugs, typos, chores, polish) on one branch, landed via one PR — rather than a single well-defined deliverable.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-fix.md`.{% endif %}
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-fix` is explicit-only because it creates GitHub issues and branches and drives an open-ended loop. While a session is active, drive it with `/iflow-fix` + `/iflow-close`, not `/iflow`.
 

--- a/src/issue_flow/templates/skills/iflow_graphify/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_graphify/SKILL.md.j2
@@ -1,22 +1,14 @@
 ---
 name: iflow-graphify
 description: >-
-  Run the /iflow-graphify slash command: rebuild the graphify knowledge graph for the
-  project (graphify-out/graph.html, GRAPH_REPORT.md, graph.json) by shelling out
-  to `issue-flow graphify` (or `graphify` directly). Off-path: never auto-dispatched
-  by /iflow. Forwards trailing args verbatim to graphify.
+  Rebuild the graphify knowledge graph (graphify-out/) by shelling out to
+  `issue-flow graphify` or `graphify` directly.
 disable-model-invocation: true
 ---
 
 # issue-flow — graph rebuild (`/iflow-graphify`)
 
-Follow this skill when the user wants to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-graphify.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-graphify`, mentions "rebuild the graph", "refresh graphify", "regenerate `GRAPH_REPORT.md`", or similar.
-- The project has a `graphify-out/` folder that is stale (large refactor, new modules, new docs/papers added) and the user asks to update it.
-- The user installed `graphifyy` for the first time and wants to produce the initial graph.
+Follow this skill to refresh the project's [graphify](https://iflow-graphify.net) knowledge graph — a stale `graphify-out/` after a large refactor, or the initial graph after installing `graphifyy`.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-graphify.md`.{% endif %}
 
 Do **not** use this skill from `/iflow-start`, `/iflow-close`, or `/iflow`. `/iflow-graphify` is opt-in only.
 

--- a/src/issue_flow/templates/skills/iflow_history_update/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_history_update/SKILL.md.j2
@@ -1,27 +1,20 @@
 ---
 name: iflow-history-update
 description: >-
-  Keep HISTORY.md (or equivalent changelog) up to date when landing an issue:
-  append a bullet to [Unreleased], or promote [Unreleased] to a new [x.y.z]
-  release section when a version bump happened. Invoked from /iflow-close.
+  Update the changelog when landing an issue: append a bullet to
+  [Unreleased], or promote it to a release section after a version bump.
 disable-model-invocation: true
 ---
 
 # issue-flow — history update
 
-Use this skill to update the project's changelog file (default **`{{ history_file }}`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step{% if commands_supported %} in `{{ agent_dir }}/{{ commands_dir }}/iflow-close.md`{% endif %}.
-
-## When to use
-
-- `/iflow-close` is landing an issue and the project has a changelog file in the repo root.
-- The user did **not** pass `nohistory` / `skip history` on the command line.
+Use this skill to update the project's changelog file (default **`{{ history_file }}`**, overridable via `ISSUEFLOW_HISTORY_FILE` in `.env`) as part of `/iflow-close`. It never runs on its own schedule; it is driven by the "update HISTORY" step{% if commands_supported %} in `{{ agent_dir }}/{{ commands_dir }}/iflow-close.md`{% endif %}, and does not run when the user passed `nohistory` / `skip history`.
 
 {% include "skills/_model_directive.md.j2" %}
 ## Preconditions
 
 1. The changelog file (`{{ history_file }}`) exists at the **project root**. If it does not, **skip** this step, print "no `{{ history_file }}` — skipping changelog update" and continue the rest of `/iflow-close`. Never create the file from this skill.
 2. The file is in **Keep a Changelog** shape: a top-level `## [Unreleased]` heading, with released versions below as `## [x.y.z] - YYYY-MM-DD` headings. If the shape does not match, **stop and report the mismatch** instead of guessing — let the user fix the file or pass `nohistory`.
-3. UTF-8 read/write with explicit encoding.
 
 ## Inputs from `/iflow-close`
 
@@ -79,7 +72,6 @@ When `/iflow-close` reaches its commit step:
 
 - Read/write only `{{ history_file }}` at the project root. Do not touch any other file from this skill.
 - Never create `{{ history_file }}` from scratch — scaffolding a starter changelog is out of scope for `issue-flow init` / `update`.
-- If the user passed `nohistory` (or `skip history`) to `/iflow-close`, don't run this skill at all.
 - If the confirm prompt in mode A or mode B is declined, leave `{{ history_file }}` untouched and print a short "skipped changelog update" note. The rest of `/iflow-close` continues normally.
 - Preserve existing formatting conventions (bullet style, sentence case, trailing punctuation). Match the style of the nearest existing entries when in doubt.
 - The new bullet's `(#<N>)` suffix is always GitHub issue `#N`, matching the focus issue's number in `{{ issueflows_dir }}/{{ current_issues_folder }}/issue<N>_original.md`.

--- a/src/issue_flow/templates/skills/iflow_iflow/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_iflow/SKILL.md.j2
@@ -1,22 +1,14 @@
 ---
 name: iflow
 description: >-
-  Run the /iflow smart dispatcher: detect where the focus issue stands in the
-  lifecycle (via files in {{ issueflows_dir }}/{{ current_issues_folder }}/ and
-  status markers) and dispatch to /iflow-init, /iflow-plan, /iflow-start, or
-  /iflow-close. Forwards trailing args verbatim. Never auto-dispatches to
-  /iflow-pause, /iflow-cleanup, or /iflow-yolo.
+  Smart dispatcher: detect where the focus issue stands and dispatch to
+  /iflow-init, /iflow-plan, /iflow-start, or /iflow-close.
 disable-model-invocation: true
 ---
 
 # issue-flow — iflow smart dispatcher (`/iflow`)
 
-Follow this skill when the user wants to run **the right next step** in the issue-flow lifecycle without remembering which specific command applies.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow`, mentions **iflow**, or asks "what's the next step?" during an issue-flow lifecycle.
-- You want a single entry point that routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close` based on current state.
+Follow this skill to run **the right next step** in the issue-flow lifecycle: it detects state and routes to `/iflow-init`, `/iflow-plan`, `/iflow-start`, or `/iflow-close`, forwarding trailing args verbatim.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow.md`.{% endif %}
 
 Do **not** use this skill for `/iflow-pick`, `/iflow-pause`, `/iflow-cleanup`, `/iflow-yolo`, or `/iflow-fix`. Those are explicit-only commands. (`/iflow-pick` is the front door *before* `/iflow-init`, for when no issue has been chosen yet. `/iflow-fix` runs an interactive iterative-fixes session, driven by `/iflow-fix` + `/iflow-close`.)
 

--- a/src/issue_flow/templates/skills/iflow_init/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_init/SKILL.md.j2
@@ -1,22 +1,14 @@
 ---
 name: iflow-init
 description: >-
-  Run the /iflow-init workflow: resolve GitHub issue reference, fetch body
-  and comments with gh, triage the comments via the iflow-comments
-  skill, write issue<number>_original.md under
-  {{ issueflows_dir }}/{{ current_issues_folder }}/, and archive other
-  current issues by done status.
+  Capture a GitHub issue locally as issue<number>_original.md and archive
+  other current issues by done status.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue init (`/iflow-init`)
 
-Follow this skill when the user wants to **capture a GitHub issue locally**.{% if commands_supported %} It uses the same rules as `{{ agent_dir }}/{{ commands_dir }}/iflow-init.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-init`, mentions **issue-init**, or asks to pull an issue into `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
-- You need a repeatable checklist without opening the command file.
+Follow this skill to **capture a GitHub issue locally** under `{{ issueflows_dir }}/{{ current_issues_folder }}/`.{% if commands_supported %} It uses the same rules as `{{ agent_dir }}/{{ commands_dir }}/iflow-init.md`.{% endif %}
 
 {% include "skills/_model_directive.md.j2" %}
 ## Instructions
@@ -40,13 +32,7 @@ Follow this skill when the user wants to **capture a GitHub issue locally**.{% i
 
 3. **Fetch** — `gh issue view <n> --repo owner/repo --json title,body,url,number,comments`. The `comments` field returns an array of `{author.login, body, createdAt, ...}` that step 3a consumes. On failure, report the error and suggest `gh auth login`. After confirming `owner/repo`, change the chat/agent tab title to reflect the issue topic on the form "Issue <issue number> <short description of issue>" (e.g. "Issue 74 cell info").
 
-3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill. Summary of rules:
-   - Process comments chronologically; **later comments win conflicts** with earlier ones.
-   - Sort points into three buckets: **Additional tasks**, **Clarifications / constraints**, **Superseded / retracted**.
-   - Collapse duplicates; drop chit-chat, emoji-only, "LGTM" and bot messages.
-   - Paraphrase — this section is an interpretive summary, not a verbatim dump.
-   - If all comments are noise, skip the curated section entirely.
-   - On open disagreement with no clear winner, log it under *Clarifications* rather than picking a side.
+3a. **Triage comments** (skip if `comments` is empty). Follow the [`iflow-comments`](../iflow-comments/SKILL.md) skill — it owns the triage rules (chronological precedence, three buckets, noise filtering) and the exact shape of the `## Comments (curated summary)` section.
 
 3.5 **Branch status preflight** (report only) — Run `git fetch --prune`. Report current branch, clean/dirty working tree, and ahead/behind counts vs `origin/<default>` (detect default via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, else `git symbolic-ref --quiet --short refs/remotes/origin/HEAD`, else `main`). If the current branch matches `^(\d+)-.+` and files for that issue already live in `{{ issueflows_dir }}/{{ partly_solved_folder }}/` or `{{ issueflows_dir }}/{{ solved_folder }}/`, note that the branch looks stale. Never delete or move anything at this step.
 
@@ -81,4 +67,3 @@ Follow this skill when the user wants to **capture a GitHub issue locally**.{% i
 ## Constraints
 
 - Allowed file operations: create/update the target `*_original.md`, and move pre-existing issue groups per the archive rules. Do not modify unrelated project files.
-- Use UTF-8 for markdown output.

--- a/src/issue_flow/templates/skills/iflow_pause/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_pause/SKILL.md.j2
@@ -1,20 +1,14 @@
 ---
 name: iflow-pause
 description: >-
-  Run the /iflow-pause workflow: update the status file with remaining work,
-  move the issue group to {{ issueflows_dir }}/{{ partly_solved_folder }}/,
-  and optionally make a WIP commit and switch to the default branch.
+  Park work on the current issue without closing it: update status, move
+  the group to {{ partly_solved_folder }}/, optional WIP commit.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue pause (`/iflow-pause`)
 
-Follow this skill when the user wants to **park work on the current issue** without closing it.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-pause.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-pause`, mentions **issue-pause**, or asks to park / stash / shelve work on an issue to switch context.
-- The issue is **not** done — this is not `/iflow-close`.
+Follow this skill to **park work on the current issue** without closing it. The issue is **not** done — this is not `/iflow-close`.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-pause.md`.{% endif %}
 
 {% include "skills/_model_directive.md.j2" %}
 ## Instructions

--- a/src/issue_flow/templates/skills/iflow_pick/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_pick/SKILL.md.j2
@@ -1,23 +1,14 @@
 ---
 name: iflow-pick
 description: >-
-  Run the /iflow-pick front door: help the user choose the next issue (parked
-  work in {{ partly_solved_folder }}/ first, else rank open GitHub issues by
-  milestone, labels, and topical similarity to recently solved work), optionally
-  create a new general-fixes issue on `fix`, create the issue branch, run
-  /iflow-init, then hand off to /iflow-plan. Off-path: never auto-dispatched by
-  /iflow. Does not auto-create sub-issues.
+  Front door: choose the next issue, create the issue branch, and run
+  /iflow-init.
 disable-model-invocation: true
 ---
 
 # issue-flow — pick next issue (`/iflow-pick`)
 
-Follow this skill when the user wants help **choosing what to work on next** and getting set up to start.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-pick.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-pick`, mentions "pick the next issue", "what should I work on next?", or "find me an issue".
-- The user is on the default branch with nothing in progress and wants a candidate plus a ready branch.
+Follow this skill to help the user **choose what to work on next** (parked work first, else ranked open GitHub issues) and get set up to start.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-pick.md`.{% endif %}
 
 Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/iflow-pick` is explicit-only because it creates GitHub issues and branches.
 
@@ -46,6 +37,8 @@ Do **not** use this skill from `/iflow`, `/iflow-start`, or `/iflow-close`. `/if
 {% if model_label_flows %}
 8. **Label-driven model profile.** If the chosen issue carries the **`{{ deep_model_label }}`** label (case-insensitive), announce that the session should use the **reasoning** profile for all steps. If it carries **`{{ fast_model_label }}`**, announce **economy**. When both match, **reasoning** wins. Configurable via `model_label_flows`, `deep_model_label`, and `fast_model_label` under `[issueflow]` in `{{ issueflows_dir }}/config.toml` (re-run `issue-flow update` after changing).
 {% endif %}
+
+### Phase 2 — create the branch
 
 1. **Require a clean tree** (`git status --porcelain`). If dirty, **stop** and ask the user to commit/stash.
 2. **Branch off the default** — switch to default, fast-forward, then `git switch -c <N>-<short-slug>` (GitHub numeric convention). Confirm a non-obvious slug.

--- a/src/issue_flow/templates/skills/iflow_plan/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_plan/SKILL.md.j2
@@ -1,21 +1,14 @@
 ---
 name: iflow-plan
 description: >-
-  Run the /iflow-plan workflow: read the focus issue in
-  {{ issueflows_dir }}/{{ current_issues_folder }}/, draft a structured plan
-  in issue<N>_plan.md, and get explicit user confirmation before any
-  implementation starts.
+  Draft a structured plan in issue<N>_plan.md and get explicit user
+  confirmation before any implementation starts.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue plan (`/iflow-plan`)
 
-Follow this skill when the user wants to **design the approach** for an issue before touching code.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-plan.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-plan`, mentions **issue-plan**, or asks you to design the approach / write a plan for the current issue.
-- You want a clear, confirmed plan before `/iflow-start` begins editing code.
+Follow this skill to **design the approach** for the focus issue before touching code, and to get the plan confirmed ahead of `/iflow-start`.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-plan.md`.{% endif %}
 
 {% include "skills/_model_directive.md.j2" %}
 ## Instructions

--- a/src/issue_flow/templates/skills/iflow_start/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_start/SKILL.md.j2
@@ -1,20 +1,14 @@
 ---
 name: iflow-start
 description: >-
-  Run the /iflow-start workflow: pick the current issue, read issue<N>_plan.md
-  (offer to run /iflow-plan if missing), then implement with the project's
-  documented conventions (e.g. uv run, or inside an activated conda env).
+  Implement the confirmed plan for the focus issue using the project's
+  documented conventions.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue start (`/iflow-start`)
 
-Follow this skill when the user wants to **begin implementation** from issue notes and project rules.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-start.md`.{% endif %} Planning itself lives in `/iflow-plan`; this skill is now implementation-only.
-
-## When to use
-
-- The user runs `/iflow-start`, mentions **issue-start**, or asks to implement from `{{ issueflows_dir }}/{{ current_issues_folder }}/`.
-- Work should follow the issue-flow markdown workflow and stay aligned with `{{ agent_dir }}/rules/issueflow-rules.mdc` when present.
+Follow this skill to **begin implementation** from issue notes and project rules.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-start.md`.{% endif %} Planning itself lives in `/iflow-plan`; this skill is implementation-only. Stay aligned with `{{ agent_dir }}/rules/issueflow-rules.mdc` when present.
 
 {% include "skills/_model_directive.md.j2" %}
 ## Instructions

--- a/src/issue_flow/templates/skills/iflow_status/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_status/SKILL.md.j2
@@ -1,22 +1,13 @@
 ---
 name: iflow-status
 description: >-
-  Run the /iflow-status report: a read-only snapshot of where every issue stands
-  — local issue-flow tracking state under {{ issueflows_dir }}/ (focus / parked /
-  solved) plus open GitHub issues cross-referenced against the local folders.
-  Off-path: never auto-dispatched by /iflow. Writes nothing.
+  Read-only snapshot of where every issue stands, locally and on GitHub.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue status overview (`/iflow-status`)
 
-Follow this skill when the user wants a bird's-eye view of every issue's status
-rather than acting on the single focus issue.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-status.md`.{% endif %}
-
-## When to use
-
-- The user runs `/iflow-status`, mentions "status of issues", "what's the state of all issues", "where do things stand", or asks for an issue overview / dashboard.
-- You want to see parked work, the focus issue's lifecycle stage, and open GitHub issues in one place.
+Follow this skill for a bird's-eye view of every issue's status — local tracking state (focus / parked / solved) plus open GitHub issues — rather than acting on the single focus issue.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-status.md`.{% endif %}
 
 Do **not** use this skill to *change* anything. It is read-only and off-path; for acting on the focus issue use `/iflow`, and to choose the next issue use `/iflow-pick`.
 

--- a/src/issue_flow/templates/skills/iflow_version_bump/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_version_bump/SKILL.md.j2
@@ -1,20 +1,14 @@
 ---
 name: iflow-version-bump
 description: >-
-  Bump the project version in pyproject.toml using uv. Supports every uv bump
-  level (major, minor, patch, stable, alpha, beta, rc, post, dev) and a
-  pre-release-aware default when no level is given. Runs from the project root.
+  Bump the project version in pyproject.toml using uv, with a
+  pre-release-aware default when no level is given.
 disable-model-invocation: true
 ---
 
 # issue-flow — version bump
 
-Use when the user wants to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`).
-
-## When to use
-
-- The user asks for a version bump — either a specific level, or just "bump" / "release" with no level (use the default rule below).
-- The repo is a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field (standard for packages using issue-flow).
+Use this skill to **bump the project version** with **uv** before landing work (often invoked from `/iflow-close`) — either at a specific level, or with the default rule below when none is given. It targets a **Python + uv** project whose `pyproject.toml` has a `[project]` `version` field.
 
 {% include "skills/_model_directive.md.j2" %}
 ## Preconditions

--- a/src/issue_flow/templates/skills/iflow_yolo/SKILL.md.j2
+++ b/src/issue_flow/templates/skills/iflow_yolo/SKILL.md.j2
@@ -1,23 +1,16 @@
 ---
 name: iflow-yolo
 description: >-
-  Run the /iflow-yolo workflow: preflight (no default branch, clean tree,
-  passing tests), single consolidated confirm, then chain init → plan → start
-  → close yolo (hands-off close: auto changelog, PR merge, default-branch
-  pull) for small, low-risk issues. Stops on any ambiguity.
+  Chain init → plan → start → close yolo for a small, low-risk issue under
+  one consolidated confirm. Stops on any ambiguity.
 disable-model-invocation: true
 ---
 
 # issue-flow — issue yolo (`/iflow-yolo`)
 
-Follow this skill when the user wants to **blast through a small, low-risk issue** in one shot.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-yolo.md`.{% endif %}
+Follow this skill to **blast through a small, low-risk issue** in one shot, with no mid-run confirmation checkpoints beyond the single consolidated confirm.{% if commands_supported %} Matches `{{ agent_dir }}/{{ commands_dir }}/iflow-yolo.md`.{% endif %}
 
 Use only for minor fixes, doc tweaks, and similar low-risk changes. Anything non-trivial should go through the individual commands.
-
-## When to use
-
-- The user runs `/iflow-yolo`, `/issue-fast`, mentions **issue-yolo**, or asks to "just do it" for a small issue.
-- The task is obviously small and the user has accepted that there will be no mid-run confirmation checkpoints.
 
 {% include "skills/_model_directive.md.j2" %}
 ## Preflight (abort on any failure)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #117.

## What

- **Vendors** mattpocock's [writing-great-skills](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-great-skills) reference (SKILL.md + GLOSSARY.md, MIT, upstream commit `d11147d`) into `.cursor/skills/writing-great-skills/` with an attribution header, so it is reachable while editing skill templates at zero context load (user-invoked).
- **Adds** `.issueflows/04-designs-and-guides/skill-authoring.md` — the decision to follow the reference plus house rules distilled for issue-flow templates.
- **Audits all 18 skill templates** under `src/issue_flow/templates/skills/` and applies behavior-preserving conformance edits:
  - Every user-invoked (`disable-model-invocation: true`) skill description trimmed to a one-line human-facing summary (per the reference, trigger-rich descriptions belong only to model-invoked skills).
  - "When to use" trigger sections removed from user-invoked skills; behavior-bearing lines (off-path rules, "do not use from /iflow") folded into the intro. Only the model-invoked `grill-me` keeps its trigger section.
  - Duplication collapsed: `iflow_init`'s inline copy of the `iflow_comments` triage rules is now a pointer; `iflow_close` defers version-bump semantics to `iflow-version-bump`; caveman's Intensity section no longer repeats its Rules; the `nohistory` rule in `iflow_history_update` lives in one place.
  - No-ops/sediment pruned ("Use UTF-8 for markdown output", stale `--bump <patch|minor|major>` level list in close).
  - Structural fix: `iflow_pick` was missing its `### Phase 2 — create the branch` heading (steps silently renumbered from 1).
- **Re-renders** this repo's own scaffold (`.cursor/skills/`, rule, doc) via `issue-flow update`.

All workflow semantics (confirmations, off-path markers, `- [x] Done` rules, file-movement rules, output contracts) are preserved; the diff is description/pruning-only plus the Phase 2 heading fix. Net: −368/+490 lines including the ~280-line vendored reference; the templates themselves shrink.

## How to test

- `uv run pytest` — 331 passed.
- `uv run ruff check src/ tests/` — clean.
- `uv run .issueflows/00-tools/verify_scaffold.py` — end-to-end scaffold render + marker checks, all passed.
- Fresh `issue-flow init` into a throwaway project confirmed the new one-line descriptions render and only `grill-me` keeps a "When to use" section.

## Known debt (out of scope, recorded in `skill-authoring.md`)

`templates/commands/*.md.j2` duplicate skill content wholesale (~1070 lines) — a single-source-of-truth violation worth its own issue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f376a-e0df-7059-ae80-122c052be858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f376a-e0df-7059-ae80-122c052be858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

