### PR TITLE
Add an Acknowledgements page to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Thanks to the authors and communities behind these projects:
 | [Jinja2](https://github.com/pallets/jinja) | Renders the scaffolded skill, command, and rules templates. | BSD-3-Clause |
 | [tomlkit](https://github.com/python-poetry/tomlkit) | Comment-preserving round-trips of `.issueflows/config.toml`. | MIT |
 | [python-dotenv](https://github.com/theskumar/python-dotenv) | Loads `ISSUEFLOW_*` settings from a project `.env`. | BSD-3-Clause |
+| [Zensical](https://github.com/zensical/zensical) | Builds the [documentation site](https://issue-flow.readthedocs.io/) (from the Material for MkDocs team). | MIT |
 
 Using or drawing on another project that should be listed here? Open a PR or issue
 to add a row.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,19 @@
+# Acknowledgements
+
+issue-flow builds on and takes inspiration from other people's open-source work.
+Thanks to the authors and communities behind these projects:
+
+| Project | How issue-flow uses it | License |
+| --- | --- | --- |
+| [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) | Inspiration for the bundled `caveman` Agent Skill (terse, token-greedy response style). Our version is a trimmed adaptation — full intensity only, English only. | [MIT](https://github.com/JuliusBrussee/caveman/blob/main/LICENSE) |
+| [mattpocock/skills](https://github.com/mattpocock/skills) | Matt Pocock's `grill-me` skill inspired the bundled `grill-me` Agent Skill (relentless planning interview). Our version is adapted to issue-flow's planning workflow, feeding conclusions into `issue<N>_plan.md`. | [MIT](https://github.com/mattpocock/skills/blob/main/LICENSE) |
+| [safishamsi/graphify](https://github.com/safishamsi/graphify) (`graphifyy` on PyPI) | Powers the optional knowledge-graph integration (`issue-flow graphify`, `graphify-out/`). Installed separately and invoked as an external tool. | [MIT](https://github.com/safishamsi/graphify/blob/main/LICENSE) |
+| [Typer](https://github.com/fastapi/typer) | The `issue-flow` command-line interface. | MIT |
+| [Rich](https://github.com/Textualize/rich) | Formatted terminal output during `init` / `update`. | MIT |
+| [Jinja2](https://github.com/pallets/jinja) | Renders the scaffolded skill, command, and rules templates. | BSD-3-Clause |
+| [tomlkit](https://github.com/python-poetry/tomlkit) | Comment-preserving round-trips of `.issueflows/config.toml`. | MIT |
+| [python-dotenv](https://github.com/theskumar/python-dotenv) | Loads `ISSUEFLOW_*` settings from a project `.env`. | BSD-3-Clause |
+| [Zensical](https://github.com/zensical/zensical) | Builds this documentation site (from the Material for MkDocs team). | MIT |
+
+Using or drawing on another project that should be listed here? Open a
+[PR or issue](https://github.com/jepegit/issue-flow/issues) to add a row.

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,8 @@ full lifecycle is described in [The workflow](issue-workflow.md).
   codebase that agents read instead of grepping.
 - **[Developing](developing.md)** — working on issue-flow itself.
 - **[Changelog](changelog.md)** — release notes.
+- **[Acknowledgements](acknowledgements.md)** — the open-source projects
+  issue-flow builds on.
 
 ## License
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -31,6 +31,7 @@ nav = [
   { "Graphify integration" = "graphify.md" },
   { "Developing" = "developing.md" },
   { "Changelog" = "changelog.md" },
+  { "Acknowledgements" = "acknowledgements.md" },
 ]
 
 [project.theme]


### PR DESCRIPTION
## What this does

Follow-up to #128: mirrors the README acknowledgements table as a page on the documentation site, linked from the navigation and the landing page. Both tables gain a new row crediting [Zensical](https://github.com/zensical/zensical) (MIT), since the documentation site itself now builds on it.

## How to test

```bash
uv sync --group docs
uv run zensical build   # "No issues found"; site/acknowledgements/ renders the table
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)