### PR TITLE
Multi-editor canonical store and convert CLI (#23)

### DIFF
--- a/.issueflows/01-current-issues/issue23_original.md
+++ b/.issueflows/01-current-issues/issue23_original.md
@@ -1,0 +1,16 @@
+# Issue #23: conversion for teams using multiple coding environments
+
+Source: https://github.com/jepegit/issue-flow/issues/23
+
+## Original issue text
+
+For teams, typically not everyone uses the same IDE or coding tools ("developer solution"). Using Git hooks, it should be possible to convert between the different formats or layouts (Cursor vs. Claude code, for example) conveniently and automatically. 
+
+Plan:
+
+1. Evaluate if there exists a common standard (search the web) that works for all solutions.
+2. If not, suggest a common standard (the issuflow format)
+3. Make sure that the codebase is refactored so that it can easily switch between solutions
+4. Create a function and/or a CLI option for converting between solutions.
+5. create a method that helps users to add git hooks    - triggered during pulling (convert to the developers' format)
+    - triggered during push (or commit?) (Convert to the format decided by the team (where the `issueflow` format is one of the options)).

--- a/.issueflows/01-current-issues/issue23_plan.md
+++ b/.issueflows/01-current-issues/issue23_plan.md
@@ -1,0 +1,150 @@
+# Issue #23 — plan
+
+## Goal
+
+Let mixed-editor teams share one repo: commit a **canonical issue-flow agent layout**, let each developer materialize their local editor surfaces (Cursor, Claude Code, opencode, Codex) on demand, and (in a follow-up) automate pull/push conversion via opt-in git hooks.
+
+## Constraints
+
+- **Back-compat:** `issue-flow init` / `update` with `--editor cursor` (default) must behave as today for solo developers who do not opt into conversion.
+- **Portable core already exists:** skills (`SKILL.md`) + `AGENTS.md` managed block + `.issueflows/` tree are editor-neutral per [editor-profiles.md](../04-designs-and-guides/editor-profiles.md).
+- **No silent hook installs:** graphify precedent ([graphify-integration.md](../04-designs-and-guides/graphify-integration.md)) — hooks are opt-in, user-confirmed, documented. Overlaps with #101 (issue-file moves) but different purpose; keep hook scripts composable.
+- **Templates stay source of truth:** canonical files are rendered from packaged Jinja2 templates, not hand-edited copies that drift from `update`.
+- **Scope limit this PR:** Phase 1 only (canonical format + refactor + `convert` CLI + docs). Git hooks land Phase 2 unless you explicitly want one large PR.
+
+### Prior art
+
+| Hit | Module / doc | Relevance |
+|-----|--------------|-----------|
+| `EditorProfile`, `EDITORS`, `resolve_editors()` | [`src/issue_flow/editors.py`](../../src/issue_flow/editors.py) | Registry of per-editor paths and surfaces — extend, don't duplicate. |
+| `build_manifest()`, `render_template()` | [`src/issue_flow/templating.py`](../../src/issue_flow/templating.py) | Manifest + render loop shared by init/update. |
+| `run_init()`, `run_update()`, `_write_manifest_files()` | [`src/issue_flow/init.py`](../../src/issue_flow/init.py) | Scaffold loop to extract into reusable `apply_profile()` / `materialize_surfaces()`. |
+| `Settings.template_context()` | [`src/issue_flow/config.py`](../../src/issue_flow/config.py) | Editor/mode/skill_level context for rendering. |
+| `verify_scaffold.py` | [`.issueflows/00-tools/verify_scaffold.py`](../00-tools/verify_scaffold.py) | Multi-editor init smoke — extend for `convert`. |
+| [editor-profiles.md](../04-designs-and-guides/editor-profiles.md) | design | Skills-first portable core; per-editor extras (`.mdc`, `CLAUDE.md`, commands). |
+| [multi-repo-workspaces.md](../04-designs-and-guides/multi-repo-workspaces.md) | design | Workspace registry orthogonal; conversion is per-repo. |
+| Agent Skills open standard | [agentskills.io](https://agentskills.io) / Cursor docs | Portable `SKILL.md` format; `.agents/skills/` is cross-tool but issue-flow already emits per-editor `agent_dir/skills/`. |
+| #101, #17 | GitHub | #101 = issue-file hook moves; #17 = Windsurf editor profile (out of scope unless you want it in the registry now). |
+
+## Standards research (issue step 1)
+
+**Finding:** No single universal config covers *all* editor surfaces today.
+
+| Surface | Portability |
+|---------|-------------|
+| `SKILL.md` skills | **Open standard** (Agent Skills / agentskills.io) — portable `name` + `description` + body. Cursor, Claude Code, Codex, VS Code Copilot, etc. consume it. |
+| `AGENTS.md` | De-facto convergent always-on rules file; issue-flow already owns a managed `<!-- BEGIN/END issue-flow -->` block. |
+| `.cursor/rules/*.mdc` | Cursor-specific (`alwaysApply`, `globs`, `paths`). |
+| `CLAUDE.md` | Claude Code-specific layering on `AGENTS.md`. |
+| Slash commands (`commands/`, `command/`) | Editor-specific paths and formats; shrinking as tools go skills-first. |
+| `.issueflows/` | **Issue-flow canonical** — already editor-neutral issue tracking. |
+
+**Conclusion:** Adopt **issue-flow canonical format** = committed `.issueflows/` + rendered skill snapshots under a neutral store + shared `AGENTS.md` block. Per-editor trees are **generated artifacts**, not the team source of truth.
+
+## Approach
+
+### Phase 1 (this PR) — canonical store + convert CLI
+
+**1. Canonical layout (new)**
+
+Introduce `.issueflows/agent/` as the team-committed store:
+
+```text
+.issueflows/
+  agent/
+    skills/<stem>/SKILL.md    # editor-neutral rendered skills (from templates)
+    manifest.json             # issue-flow version, mode, skill_level, surfaces included
+  config.toml                 # add canonical_format = true, optional team_editor hint
+AGENTS.md                     # managed block (unchanged mechanism)
+```
+
+- Populated by `issue-flow init --canonical` or `issue-flow convert --to canonical`.
+- Editor dirs (`.cursor/`, `.claude/`, `.opencode/`, `.codex/`) become **local-only** when `canonical_format = true` — document a `.gitignore` snippet (or `issue-flow convert --gitignore`) listing them.
+
+**2. Refactor scaffold loop (issue step 3)**
+
+Extract from `init.py`:
+
+- `materialize_surfaces(project_root, profiles, *, mode, skill_level, force, target: Literal["editor","canonical"])`
+- `init` / `update` call `target="editor"` (current behaviour).
+- `convert` calls `target="editor"` for one profile or `target="canonical"` for the neutral store.
+
+No second template tree — same `build_manifest()` + `_write_manifest_files()` paths, different output root mapping in one place.
+
+**3. CLI (issue step 4)**
+
+```bash
+issue-flow convert --to cursor          # local dev: canonical → .cursor/ (+ docs, .mdc, AGENTS.md)
+issue-flow convert --to claude
+issue-flow convert --to canonical       # team: strip local editor dirs, refresh .issueflows/agent/
+issue-flow convert --prune-other        # remove non-target editor trees after convert
+```
+
+Resolution order for target editor: `--to` flag > `ISSUEFLOW_EDITOR` / `.env` > `config.toml` `[issueflow].editor` (new persisted key, optional).
+
+`convert` reuses active `mode` + `skill_level` from `config.toml` (same as `update`).
+
+**4. Docs + design record**
+
+- New `.issueflows/04-designs-and-guides/multi-editor-conversion.md` — canonical format, team vs solo workflows, gitignore guidance.
+- Update `docs/configuration.md` — `canonical_format`, `convert`, editor persistence.
+- README future-work cross-link.
+
+**5. Tests**
+
+- Unit: output path mapping canonical vs editor; `--prune-other` only removes known manifest paths.
+- Integration: init canonical → convert to claude + cursor → assert skills present, no cross-editor leakage (reuse `test_templating` patterns).
+- Extend `verify_scaffold.py` or parallel test for convert round-trip.
+
+### Phase 2 (follow-up / can split to #101-adjacent issue) — git hooks (issue step 5)
+
+```bash
+issue-flow hooks install convert   # opt-in, shows script before writing
+```
+
+| Hook | Action |
+|------|--------|
+| `post-merge` / `post-checkout` | `issue-flow convert --to $ISSUEFLOW_EDITOR` (materialize local editor) |
+| `pre-push` (default) or `pre-commit` (configurable) | `issue-flow convert --to canonical --prune-other` (ensure team format committed) |
+
+- Scripts call installed `issue-flow` on PATH; fail loudly if missing.
+- Document composing with #101's issue-file hooks (separate scripts, shared `core.hooksPath` or chained calls).
+- **Open question:** pre-push vs pre-commit for canonicalization — see below.
+
+## Files to touch
+
+| Path | Change |
+|------|--------|
+| `src/issue_flow/init.py` | Extract `materialize_surfaces()`; optional canonical writer. |
+| `src/issue_flow/convert.py` | **New** — convert orchestration, prune logic. |
+| `src/issue_flow/cli.py` | `convert` subcommand; optional `init --canonical` flag. |
+| `src/issue_flow/config.py` | `canonical_format`, persisted `editor` keys; template context for canonical paths. |
+| `src/issue_flow/templating.py` | Canonical manifest helper (skills subset → `.issueflows/agent/skills/`). |
+| `src/issue_flow/templates/config.toml.j2` | Document new keys (if template exists). |
+| `docs/configuration.md` | User-facing config for conversion workflow. |
+| `.issueflows/04-designs-and-guides/multi-editor-conversion.md` | **New** design doc. |
+| `tests/test_convert.py` | **New** |
+| `tests/test_init.py` / `tests/test_templating.py` | Adjust for extracted helper. |
+| `.issueflows/00-tools/verify_scaffold.py` | Optional convert smoke. |
+
+## Test strategy
+
+```bash
+uv run pytest tests/test_convert.py tests/test_init.py tests/test_templating.py tests/test_editors.py
+uv run ruff check src/ tests/
+```
+
+Manual smoke: scaffold throwaway repo with `init --canonical`, `convert --to claude`, verify `.claude/skills/iflow-init/SKILL.md` exists and `.issueflows/agent/` unchanged.
+
+## Open questions
+
+1. **Phase boundary:** Implement Phase 1 only in this PR (recommended), or include git hooks now?
+2. **Canonicalization hook timing:** Default `pre-push` (safer — avoids mid-commit surprise) or `pre-commit` (stricter — never commit local editor trees)?
+3. **Solo back-compat:** Should `init` without flags keep writing `.cursor/` into git as today, or should we nudge new projects toward canonical + gitignored editor dirs in docs only?
+4. **Windsurf (#17):** Defer until `EditorProfile` exists, or add stub profile in this work?
+
+## Scope check
+
+Full issue (#23) spans research + refactor + CLI + hooks — **too large for one focused PR**. This plan delivers the architectural refactor and conversion CLI (steps 1–4); hooks (step 5) are a clear Phase 2 with explicit overlap notes for #101.
+
+If you want smaller still, Phase 1a could be refactor + `convert --to <editor>` only (no canonical store / gitignore), but that weakens the team story — canonical store is the point of the issue.

--- a/.issueflows/01-current-issues/issue23_status.md
+++ b/.issueflows/01-current-issues/issue23_status.md
@@ -1,0 +1,18 @@
+# Issue #23 — status
+
+- [ ] Done
+
+## What's done
+
+- `materialize_surfaces` extracted to `src/issue_flow/surfaces.py`.
+- Canonical store: `.issueflows/agent/skills/` + `manifest.json`.
+- CLI: `issue-flow convert --to <editor|canonical>` (`--prune-other`, `--gitignore`).
+- `issue-flow init --canonical` for team bootstrap.
+- Config: `canonical_format`, persisted `editor` in `config.toml`.
+- Tests: `tests/test_convert.py` (5 cases).
+- Docs: `docs/configuration.md`, `multi-editor-conversion.md`.
+
+## Remaining work
+
+- Phase 2: opt-in git hooks for pull/push conversion (#23 step 5).
+- Optional: extend `verify_scaffold.py` for convert round-trip smoke.

--- a/.issueflows/04-designs-and-guides/multi-editor-conversion.md
+++ b/.issueflows/04-designs-and-guides/multi-editor-conversion.md
@@ -1,0 +1,34 @@
+# Multi-editor conversion
+
+Context: issue #23 — teams where developers use different AI coding tools need
+a shared git layout and local materialization of editor-specific surfaces.
+
+## Decision
+
+- **Canonical store in git:** `.issueflows/agent/skills/` (rendered `SKILL.md`
+  snapshots) + `manifest.json` + existing `.issueflows/` issue tracking +
+  `AGENTS.md` managed block.
+- **Generated locally:** per-editor trees (`.cursor/`, `.claude/`, `.opencode/`,
+  `.codex/`), optional `CLAUDE.md`, workflow doc under `docs/`.
+- **CLI:** `issue-flow convert --to <editor|canonical>` with `--prune-other` and
+  `--gitignore`. `issue-flow init --canonical` bootstraps the team workflow.
+- **Standards:** Agent Skills (`SKILL.md`, agentskills.io) is the portable core;
+  no universal format exists for rules/commands — issue-flow renders those per
+  profile from the shared template tree ([editor-profiles.md](editor-profiles.md)).
+
+## Solo vs team
+
+| Workflow | Init | Git commits |
+| --- | --- | --- |
+| Solo (default) | `issue-flow init` | `.cursor/` (or chosen editor) as today |
+| Team | `issue-flow init --canonical` | `.issueflows/agent/` + `AGENTS.md`; editor dirs gitignored |
+
+## Deferred
+
+- Opt-in git hooks (`post-checkout` → local editor, `pre-push` → canonical) —
+  phase 2 of #23; compose separately from #101 issue-file hooks.
+- Windsurf `EditorProfile` (#17).
+
+## Link
+
+- Issue: [#23](https://github.com/jepegit/issue-flow/issues/23)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,39 @@ guidance is. It is set with `init --skill-level <level>`, persisted to
 Resolution order mirrors modes: `--skill-level` (CLI) > `config.toml` >
 `ISSUEFLOW_SKILL_LEVEL` (env) > `standard`.
 
+## Multi-editor teams (canonical format)
+
+When teammates use different AI coding tools (Cursor, Claude Code, opencode,
+Codex), issue-flow can keep a **team-committed canonical store** under
+`.issueflows/agent/` (portable `SKILL.md` snapshots + `manifest.json`) plus the
+shared `AGENTS.md` managed block. Per-editor trees (`.cursor/`, `.claude/`, …)
+are generated locally and can be gitignored.
+
+```bash
+# Team setup: commit .issueflows/agent/ instead of every editor tree
+issue-flow init --canonical
+
+# After checkout: materialize your local editor surfaces
+issue-flow convert --to cursor          # or claude, opencode, codex
+
+# Before push: refresh canonical store and drop local editor trees
+issue-flow convert --to canonical --prune-other
+```
+
+Persisted keys in `config.toml`:
+
+| Key | Purpose |
+| --- | --- |
+| `canonical_format = true` | Project uses the canonical store in git (set by `init --canonical` or `convert --to canonical`). |
+| `editor = "cursor"` | Last local editor target for `convert` (optional; `ISSUEFLOW_EDITOR` still wins when set). |
+
+`init --canonical` also appends a managed `.gitignore` block for local editor
+directories. Re-run with `issue-flow convert --gitignore` if you adopted the
+workflow later.
+
+Git hooks for automatic pull/push conversion are planned as a follow-up (#23
+phase 2 / #101-adjacent); hooks remain opt-in.
+
 ## Caveman skill
 
 The `standard` mode installs an optional `caveman` Agent Skill

--- a/src/issue_flow/agent.py
+++ b/src/issue_flow/agent.py
@@ -1103,16 +1103,17 @@ def run_workspace_update(
     if not skip_dep_check and not _dependency_gate(skip_dep_check=False):
         return 1
 
-    import issue_flow.init as init_module
+    import issue_flow.console_io as console_module
 
     def _run_member_update(root: Path) -> None:
         if as_json:
-            saved = init_module.console
-            init_module.console = Console(quiet=True)
+            quiet = Console(quiet=True)
+            saved = console_module.console
+            console_module.console = quiet
             try:
                 run_update(root, skip_dep_check=True, editors=editors)
             finally:
-                init_module.console = saved
+                console_module.console = saved
         else:
             run_update(root, skip_dep_check=True, editors=editors)
 

--- a/src/issue_flow/cli.py
+++ b/src/issue_flow/cli.py
@@ -132,6 +132,15 @@ def init(
         "--skill-level",
         help=_SKILL_LEVEL_HELP,
     ),
+    canonical: bool = typer.Option(
+        False,
+        "--canonical",
+        help=(
+            "Scaffold the team-committed canonical store under .issueflows/agent/ "
+            "instead of per-editor trees. Adds a managed .gitignore block for "
+            "local editor directories."
+        ),
+    ),
 ) -> None:
     """Scaffold issue-flow directories and editor config files in a project."""
     from issue_flow.init import run_init
@@ -143,6 +152,54 @@ def init(
         editors=editor,
         mode=mode,
         skill_level=skill_level,
+        canonical=canonical,
+    )
+
+
+@app.command()
+def convert(
+    project_dir: Path = typer.Argument(
+        default=Path("."),
+        help="Project root directory (defaults to current directory).",
+        exists=True,
+        file_okay=False,
+        resolve_path=True,
+    ),
+    to: str | None = typer.Option(
+        None,
+        "--to",
+        help=(
+            "Target layout: an editor id (cursor, claude, opencode, codex) or "
+            "'canonical' for the team store under .issueflows/agent/. Defaults "
+            "to ISSUEFLOW_EDITOR / config.toml / cursor."
+        ),
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite existing manifest outputs.",
+    ),
+    prune_other: bool = typer.Option(
+        False,
+        "--prune-other",
+        help="Remove scaffold trees for non-target editors after converting.",
+    ),
+    gitignore: bool = typer.Option(
+        False,
+        "--gitignore",
+        help="Append a managed .gitignore block for local editor directories.",
+    ),
+) -> None:
+    """Convert between canonical and per-editor issue-flow scaffold layouts."""
+    from issue_flow.convert import run_convert
+
+    run_convert(
+        project_root=project_dir,
+        to=to,
+        force=force,
+        prune_other=prune_other,
+        gitignore=gitignore,
     )
 
 

--- a/src/issue_flow/config.py
+++ b/src/issue_flow/config.py
@@ -232,6 +232,34 @@ class Settings:
             return env.strip()
         return DEFAULT_SKILL_LEVEL
 
+    def resolve_canonical_format(self, project_root: Path) -> bool:
+        """Return whether the project uses the canonical agent store in git."""
+        persisted = modes_module.read_canonical_format(self.config_path(project_root))
+        if persisted is not None:
+            return persisted
+        return False
+
+    def resolve_persisted_editor(self, project_root: Path) -> str | None:
+        """Return the editor id persisted in ``config.toml``, if any."""
+        return modes_module.read_persisted_editor(self.config_path(project_root))
+
+    def resolve_target_editor(self, project_root: Path, cli_editor: str | None) -> str:
+        """Resolve the editor for ``convert --to <editor>``.
+
+        Order: explicit CLI value > ``ISSUEFLOW_EDITOR`` env > persisted
+        ``config.toml`` > default ``cursor``. The special value ``canonical`` is
+        passed through unchanged.
+        """
+        if cli_editor:
+            return cli_editor.strip().lower()
+        env = os.getenv("ISSUEFLOW_EDITOR")
+        if env and env.strip():
+            return env.strip().lower()
+        persisted = self.resolve_persisted_editor(project_root)
+        if persisted:
+            return persisted
+        return DEFAULT_EDITOR
+
     def seed_config_values(self) -> dict[str, object]:
         """Values for a freshly created ``config.toml``: env/``.env`` else defaults.
 

--- a/src/issue_flow/console_io.py
+++ b/src/issue_flow/console_io.py
@@ -1,0 +1,7 @@
+"""Shared Rich console for issue-flow CLI output."""
+
+from __future__ import annotations
+
+from rich.console import Console
+
+console = Console()

--- a/src/issue_flow/convert.py
+++ b/src/issue_flow/convert.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 
 import typer
-from rich.console import Console
 
 from issue_flow import modes as modes_module
+import issue_flow.console_io as console_io
 from issue_flow.config import Settings
 from issue_flow.editors import get_profile
 from issue_flow.init import _create_issueflow_dirs, _ensure_agents_md
@@ -18,9 +18,6 @@ from issue_flow.surfaces import (
     prune_all_editor_surfaces,
     prune_other_editor_surfaces,
 )
-
-console = Console()
-
 
 def run_convert(
     project_root: Path,
@@ -45,24 +42,24 @@ def run_convert(
     try:
         mode_obj = settings.resolve_mode(project_root)
     except ValueError as exc:
-        console.print(f"[red]error[/red]  {exc}")
+        console_io.console.print(f"[red]error[/red]  {exc}")
         raise typer.Exit(code=2) from None
 
     skill_level_id = settings.resolve_skill_level(project_root)
     target = settings.resolve_target_editor(project_root, to)
     cfg_path = settings.config_path(project_root)
 
-    console.print(
+    console_io.console.print(
         f"\n[bold]Converting issue-flow surfaces in [cyan]{project_root}[/cyan][/bold]"
     )
-    console.print(f"[dim]Target: {target}[/dim]")
-    console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
-    console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
+    console_io.console.print(f"[dim]Target: {target}[/dim]")
+    console_io.console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
+    console_io.console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
 
     _create_issueflow_dirs(project_root, settings)
 
     if target == "canonical":
-        console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
+        console_io.console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
         result = materialize_canonical_store(
             project_root,
             settings,
@@ -72,7 +69,7 @@ def run_convert(
             ensure_agents_md=_ensure_agents_md,
         )
         modes_module.write_canonical_format(cfg_path, True)
-        console.print(
+        console_io.console.print(
             f"  [green]write[/green] {cfg_path.relative_to(project_root).as_posix()}  "
             "(canonical_format = true)"
         )
@@ -85,10 +82,10 @@ def run_convert(
         try:
             profile = get_profile(target)
         except ValueError as exc:
-            console.print(f"[red]error[/red]  {exc}")
+            console_io.console.print(f"[red]error[/red]  {exc}")
             raise typer.Exit(code=2) from None
 
-        console.print(
+        console_io.console.print(
             f"[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
         )
         result = materialize_editor_profile(
@@ -114,23 +111,23 @@ def run_convert(
     if gitignore:
         ensure_editor_gitignore(project_root)
 
-    console.print()
+    console_io.console.print()
     if result.written:
-        console.print(
+        console_io.console.print(
             f"[bold green]Wrote {len(result.written)} file(s).[/bold green]"
         )
     if result.skipped:
-        console.print(
+        console_io.console.print(
             f"[bold yellow]Skipped {len(result.skipped)} existing file(s).[/bold yellow]"
         )
     if result.pruned:
-        console.print(
+        console_io.console.print(
             f"[bold yellow]Pruned {result.pruned} scaffold path(s).[/bold yellow]"
         )
     if not result.written and not result.skipped and not result.pruned:
-        console.print("[bold]Nothing to do.[/bold]")
+        console_io.console.print("[bold]Nothing to do.[/bold]")
 
-    console.print(
+    console_io.console.print(
         "\n[dim]Editor-specific trees are generated artifacts. When using the "
         "canonical workflow, commit [bold].issueflows/agent/[/bold] and "
         "[bold]AGENTS.md[/bold]; run [bold]issue-flow convert --to <editor>[/bold] "

--- a/src/issue_flow/convert.py
+++ b/src/issue_flow/convert.py
@@ -1,0 +1,138 @@
+"""Convert between canonical and per-editor issue-flow scaffold layouts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from issue_flow import modes as modes_module
+from issue_flow.config import Settings
+from issue_flow.editors import get_profile
+from issue_flow.init import _create_issueflow_dirs, _ensure_agents_md
+from issue_flow.surfaces import (
+    ensure_editor_gitignore,
+    materialize_canonical_store,
+    materialize_editor_profile,
+    prune_all_editor_surfaces,
+    prune_other_editor_surfaces,
+)
+
+console = Console()
+
+
+def run_convert(
+    project_root: Path,
+    *,
+    to: str | None = None,
+    force: bool = False,
+    prune_other: bool = False,
+    gitignore: bool = False,
+) -> None:
+    """Materialize canonical or per-editor scaffold surfaces.
+
+    Args:
+        project_root: Absolute path to the user's project directory.
+        to: Target layout — an editor id (``cursor``, ``claude``, …) or
+            ``canonical`` for the team-committed store under
+            ``.issueflows/agent/``.
+        force: Overwrite existing manifest outputs.
+        prune_other: Remove scaffold trees for non-target editors afterward.
+        gitignore: Append a managed ``.gitignore`` block for local editor dirs.
+    """
+    settings = Settings()
+    try:
+        mode_obj = settings.resolve_mode(project_root)
+    except ValueError as exc:
+        console.print(f"[red]error[/red]  {exc}")
+        raise typer.Exit(code=2) from None
+
+    skill_level_id = settings.resolve_skill_level(project_root)
+    target = settings.resolve_target_editor(project_root, to)
+    cfg_path = settings.config_path(project_root)
+
+    console.print(
+        f"\n[bold]Converting issue-flow surfaces in [cyan]{project_root}[/cyan][/bold]"
+    )
+    console.print(f"[dim]Target: {target}[/dim]")
+    console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
+    console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
+
+    _create_issueflow_dirs(project_root, settings)
+
+    if target == "canonical":
+        console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
+        result = materialize_canonical_store(
+            project_root,
+            settings,
+            mode_obj,
+            skill_level_id,
+            force=force,
+            ensure_agents_md=_ensure_agents_md,
+        )
+        modes_module.write_canonical_format(cfg_path, True)
+        console.print(
+            f"  [green]write[/green] {cfg_path.relative_to(project_root).as_posix()}  "
+            "(canonical_format = true)"
+        )
+        if prune_other:
+            pruned = prune_all_editor_surfaces(
+                project_root, settings, mode_obj, skill_level_id
+            )
+            result.pruned += pruned
+    else:
+        try:
+            profile = get_profile(target)
+        except ValueError as exc:
+            console.print(f"[red]error[/red]  {exc}")
+            raise typer.Exit(code=2) from None
+
+        console.print(
+            f"[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
+        )
+        result = materialize_editor_profile(
+            project_root,
+            settings,
+            profile,
+            mode_obj,
+            skill_level_id,
+            force=force,
+            prune=True,
+            ensure_agents_md=_ensure_agents_md,
+        )
+        modes_module.write_persisted_editor(cfg_path, profile.id)
+        if prune_other:
+            result.pruned += prune_other_editor_surfaces(
+                project_root,
+                settings,
+                keep_profile=profile,
+                mode=mode_obj,
+                skill_level=skill_level_id,
+            )
+
+    if gitignore:
+        ensure_editor_gitignore(project_root)
+
+    console.print()
+    if result.written:
+        console.print(
+            f"[bold green]Wrote {len(result.written)} file(s).[/bold green]"
+        )
+    if result.skipped:
+        console.print(
+            f"[bold yellow]Skipped {len(result.skipped)} existing file(s).[/bold yellow]"
+        )
+    if result.pruned:
+        console.print(
+            f"[bold yellow]Pruned {result.pruned} scaffold path(s).[/bold yellow]"
+        )
+    if not result.written and not result.skipped and not result.pruned:
+        console.print("[bold]Nothing to do.[/bold]")
+
+    console.print(
+        "\n[dim]Editor-specific trees are generated artifacts. When using the "
+        "canonical workflow, commit [bold].issueflows/agent/[/bold] and "
+        "[bold]AGENTS.md[/bold]; run [bold]issue-flow convert --to <editor>[/bold] "
+        "after checkout.[/dim]\n"
+    )

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -7,10 +7,10 @@ import shutil
 from pathlib import Path
 
 import typer
-from rich.console import Console
 
 from issue_flow import modes as modes_module
 from issue_flow.config import Settings
+import issue_flow.console_io as console_io
 from issue_flow.dependencies import (
     check_dependencies,
     prompt_or_skip,
@@ -34,8 +34,6 @@ from issue_flow.templating import (
     resolve_output_path,
     skill_output_name,
 )
-
-console = Console()
 
 # Optional project-root `.env` entries (see README). Values are defaults for comments only.
 _DOTENV_KEYS: tuple[tuple[str, str], ...] = (
@@ -91,7 +89,7 @@ def _ensure_dotenv_file(project_root: Path) -> None:
         for key, default in _DOTENV_KEYS:
             lines.append(f"# {key}={default}\n")
         env_path.write_text("".join(lines), encoding="utf-8")
-        console.print(f"  [green]write[/green] {relative}")
+        console_io.console.print(f"  [green]write[/green] {relative}")
         return
 
     existing = env_path.read_text(encoding="utf-8")
@@ -99,7 +97,7 @@ def _ensure_dotenv_file(project_root: Path) -> None:
         (k, d) for k, d in _DOTENV_KEYS if not _dotenv_documents_key(existing, k)
     ]
     if not missing:
-        console.print(
+        console_io.console.print(
             f"  [dim]skip[/dim]  {relative}  "
             "(already lists ISSUEFLOW_* settings; not modified)"
         )
@@ -110,7 +108,7 @@ def _ensure_dotenv_file(project_root: Path) -> None:
         block.append(f"# {key}={default}\n")
     with env_path.open("a", encoding="utf-8") as f:
         f.write("".join(block))
-    console.print(
+    console_io.console.print(
         f"  [green]append[/green] {relative}  "
         f"(added {len(missing)} commented ISSUEFLOW_* line(s))"
     )
@@ -149,7 +147,7 @@ def _ensure_agents_md(project_root: Path, context: dict[str, str]) -> None:
 
     if not path.exists():
         path.write_text(block, encoding="utf-8")
-        console.print(f"  [green]write[/green] {relative}  (issue-flow managed block)")
+        console_io.console.print(f"  [green]write[/green] {relative}  (issue-flow managed block)")
         return
 
     existing = path.read_text(encoding="utf-8")
@@ -158,19 +156,19 @@ def _ensure_agents_md(project_root: Path, context: dict[str, str]) -> None:
         replacement = f"{_AGENTS_BEGIN}\n{rendered}{_AGENTS_END}"
         updated = _AGENTS_BLOCK_RE.sub(lambda _m: replacement, existing)
         if updated == existing:
-            console.print(
+            console_io.console.print(
                 f"  [dim]skip[/dim]  {relative}  (issue-flow block already up to date)"
             )
             return
         path.write_text(updated, encoding="utf-8")
-        console.print(
+        console_io.console.print(
             f"  [green]update[/green] {relative}  (refreshed issue-flow managed block)"
         )
         return
 
     updated = existing.rstrip("\n") + "\n\n" + block
     path.write_text(updated, encoding="utf-8")
-    console.print(
+    console_io.console.print(
         f"  [green]append[/green] {relative}  (added issue-flow managed block)"
     )
 
@@ -192,13 +190,13 @@ def _ensure_project_brief(
     path = project_root / relative
 
     if path.exists():
-        console.print(f"  [dim]skip[/dim]  {relative}  (project brief already exists)")
+        console_io.console.print(f"  [dim]skip[/dim]  {relative}  (project brief already exists)")
         return
 
     rendered = render_template("docs/this-project.md.j2", context)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(rendered, encoding="utf-8")
-    console.print(f"  [green]write[/green] {relative}")
+    console_io.console.print(f"  [green]write[/green] {relative}")
 
 
 def _ensure_tools_readme(
@@ -216,13 +214,13 @@ def _ensure_tools_readme(
     path = project_root / relative
 
     if path.exists():
-        console.print(f"  [dim]skip[/dim]  {relative}  (tools README already exists)")
+        console_io.console.print(f"  [dim]skip[/dim]  {relative}  (tools README already exists)")
         return
 
     rendered = render_template("tools/README.md.j2", context)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(rendered, encoding="utf-8")
-    console.print(f"  [green]write[/green] {relative}")
+    console_io.console.print(f"  [green]write[/green] {relative}")
 
 
 def _already_initialized(
@@ -297,7 +295,7 @@ def run_init(
     try:
         profiles = resolve_editors(editors)
     except ValueError as exc:
-        console.print(f"[red]error[/red]  {exc}")
+        console_io.console.print(f"[red]error[/red]  {exc}")
         raise typer.Exit(code=2) from None
 
     cfg_path = settings.config_path(project_root)
@@ -306,7 +304,7 @@ def run_init(
     try:
         mode_obj = modes_module.resolve_mode(mode_id, cfg_path)
     except ValueError as exc:
-        console.print(f"[red]error[/red]  {exc}")
+        console_io.console.print(f"[red]error[/red]  {exc}")
         raise typer.Exit(code=2) from None
 
     explicit_skill_level = skill_level is not None
@@ -316,27 +314,27 @@ def run_init(
         else settings.resolve_skill_level(project_root)
     )
     if skill_level_id not in modes_module.SKILL_LEVELS:
-        console.print(
+        console_io.console.print(
             f"[red]error[/red]  Invalid skill level '{skill_level_id}'. "
             f"Choose from: {', '.join(modes_module.SKILL_LEVELS)}"
         )
         raise typer.Exit(code=2)
 
-    console.print(
+    console_io.console.print(
         f"\n[bold]Initializing issue-flow in [cyan]{project_root}[/cyan][/bold]"
     )
     if canonical:
-        console.print("[dim]Layout: canonical (.issueflows/agent/)[/dim]")
+        console_io.console.print("[dim]Layout: canonical (.issueflows/agent/)[/dim]")
     else:
-        console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
-    console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
-    console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
+        console_io.console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
+    console_io.console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
+    console_io.console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
 
     if not _dependency_gate(skip_dep_check):
         raise typer.Exit(code=1)
 
     if not force and _already_initialized(project_root, settings, profiles):
-        console.print(
+        console_io.console.print(
             "[dim]This project already has issue-flow scaffold files. "
             "Existing files are skipped so your issue notes stay intact. "
             "Run [bold]issue-flow update[/bold] to refresh commands, rules, and docs "
@@ -350,7 +348,7 @@ def run_init(
             modes_module.write_active_mode(cfg_path, mode_obj.id)
         if explicit_skill_level:
             modes_module.write_skill_level(cfg_path, skill_level_id)
-        console.print(
+        console_io.console.print(
             f"  [green]write[/green] {cfg_path.relative_to(project_root).as_posix()}  "
             f"(mode = {mode_obj.id}, skill_level = {skill_level_id})"
         )
@@ -374,7 +372,7 @@ def run_init(
     pruned_count = 0
 
     if canonical:
-        console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
+        console_io.console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
         result = materialize_canonical_store(
             project_root,
             settings,
@@ -386,14 +384,14 @@ def run_init(
         written_files.extend(result.written)
         skipped_files.extend(result.skipped)
         modes_module.write_canonical_format(cfg_path, True)
-        console.print(
+        console_io.console.print(
             f"  [green]write[/green] {cfg_path.relative_to(project_root).as_posix()}  "
             "(canonical_format = true)"
         )
         ensure_editor_gitignore(project_root)
     else:
         for profile in profiles:
-            console.print(
+            console_io.console.print(
                 f"\n[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
             )
             result = materialize_editor_profile(
@@ -410,33 +408,33 @@ def run_init(
             skipped_files.extend(result.skipped)
             pruned_count += result.pruned
 
-    console.print()
+    console_io.console.print()
     _ensure_dotenv_file(project_root)
 
-    console.print()
+    console_io.console.print()
     if not canonical:
         _graphify_postinstall(project_root, profiles)
 
-    console.print()
+    console_io.console.print()
     if written_files:
-        console.print(f"[bold green]Created {len(written_files)} file(s).[/bold green]")
+        console_io.console.print(f"[bold green]Created {len(written_files)} file(s).[/bold green]")
     if skipped_files:
-        console.print(
+        console_io.console.print(
             f"[bold yellow]Skipped {len(skipped_files)} existing file(s).[/bold yellow]"
         )
     if pruned_count:
-        console.print(
+        console_io.console.print(
             f"[bold yellow]Pruned {pruned_count} retired scaffold file(s).[/bold yellow]"
         )
     if not written_files and not skipped_files and not pruned_count:
-        console.print("[bold]Nothing to do.[/bold]")
+        console_io.console.print("[bold]Nothing to do.[/bold]")
 
     primary = profiles[0]
     if canonical:
         hint_dir = f"{settings.issueflows_dir}/agent/skills/"
     else:
         hint_dir = f"{primary.agent_dir}/skills/"
-    console.print(
+    console_io.console.print(
         "\n[dim]Run [bold]/iflow-init <number>[/bold] or [bold]/iflow-init[/bold] "
         "(on a branch like [bold]42-slug[/bold], after confirmation) in your editor "
         "to start tracking a GitHub issue. "
@@ -477,22 +475,22 @@ def run_update(
     try:
         profiles = resolve_editors(editors)
     except ValueError as exc:
-        console.print(f"[red]error[/red]  {exc}")
+        console_io.console.print(f"[red]error[/red]  {exc}")
         raise typer.Exit(code=2) from None
 
     try:
         mode_obj = settings.resolve_mode(project_root)
     except ValueError as exc:
-        console.print(f"[red]error[/red]  {exc}")
+        console_io.console.print(f"[red]error[/red]  {exc}")
         raise typer.Exit(code=2) from None
 
     skill_level_id = settings.resolve_skill_level(project_root)
-    console.print(
+    console_io.console.print(
         f"\n[bold]Updating issue-flow scaffold in [cyan]{project_root}[/cyan][/bold]"
     )
-    console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
-    console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
-    console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
+    console_io.console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
+    console_io.console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
+    console_io.console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
 
     if not _dependency_gate(skip_dep_check):
         raise typer.Exit(code=1)
@@ -516,7 +514,7 @@ def run_update(
     written_files: list[Path] = []
     pruned_count = 0
     for profile in profiles:
-        console.print(
+        console_io.console.print(
             f"\n[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
         )
         result = materialize_editor_profile(
@@ -532,22 +530,22 @@ def run_update(
         written_files.extend(result.written)
         pruned_count += result.pruned
 
-    console.print()
+    console_io.console.print()
     _graphify_postinstall(project_root, profiles)
 
-    console.print()
+    console_io.console.print()
     if written_files:
-        console.print(
+        console_io.console.print(
             f"[bold green]Refreshed {len(written_files)} file(s).[/bold green]"
         )
     if pruned_count:
-        console.print(
+        console_io.console.print(
             f"[bold yellow]Pruned {pruned_count} retired scaffold file(s).[/bold yellow]"
         )
     if not written_files and not pruned_count:
-        console.print("[bold]Nothing to write.[/bold]")
+        console_io.console.print("[bold]Nothing to write.[/bold]")
 
-    console.print(
+    console_io.console.print(
         "\n[dim]Manifest outputs were overwritten from the installed package. "
         "Issue files under [bold].issueflows/[/bold] were not modified by this command.[/dim]\n"
     )
@@ -592,7 +590,7 @@ def _prune_retired_files(
 
             shutil.rmtree(old_folder)
             relative = old_folder.relative_to(project_root)
-            console.print(f"  [yellow]prune[/yellow]  {relative}")
+            console_io.console.print(f"  [yellow]prune[/yellow]  {relative}")
             pruned_count += 1
 
     return pruned_count
@@ -615,13 +613,13 @@ def _prune_command_files(
         if command_file.exists():
             command_file.unlink()
             relative = command_file.relative_to(project_root)
-            console.print(f"  [yellow]prune[/yellow]  {relative}")
+            console_io.console.print(f"  [yellow]prune[/yellow]  {relative}")
             pruned_count += 1
 
     if remove_empty_dir and cmd_dir.is_dir() and not any(cmd_dir.iterdir()):
         cmd_dir.rmdir()
         relative = cmd_dir.relative_to(project_root)
-        console.print(f"  [yellow]prune[/yellow]  {relative}/")
+        console_io.console.print(f"  [yellow]prune[/yellow]  {relative}/")
         pruned_count += 1
 
     return pruned_count
@@ -648,7 +646,7 @@ def _prune_excluded_surfaces(
         folder = skills_dir / skill_output_name(skill_dir)
         if folder.exists():
             shutil.rmtree(folder)
-            console.print(
+            console_io.console.print(
                 f"  [yellow]prune[/yellow]  {folder.relative_to(project_root)}  "
                 f"(excluded by mode {mode.id})"
             )
@@ -662,7 +660,7 @@ def _prune_excluded_surfaces(
             command_file = cmd_dir / f"{name}.md"
             if command_file.exists():
                 command_file.unlink()
-                console.print(
+                console_io.console.print(
                     f"  [yellow]prune[/yellow]  "
                     f"{command_file.relative_to(project_root)}  "
                     f"(excluded by mode {mode.id})"
@@ -670,7 +668,7 @@ def _prune_excluded_surfaces(
                 pruned_count += 1
         if cmd_dir.is_dir() and not any(cmd_dir.iterdir()):
             cmd_dir.rmdir()
-            console.print(
+            console_io.console.print(
                 f"  [yellow]prune[/yellow]  {cmd_dir.relative_to(project_root)}/"
             )
             pruned_count += 1
@@ -693,7 +691,7 @@ def _graphify_postinstall(project_root: Path, profiles: list[EditorProfile]) -> 
     if not installable:
         return
 
-    console.print("[bold]Graphify integration[/bold]")
+    console_io.console.print("[bold]Graphify integration[/bold]")
     seen: set[str] = set()
     for profile in installable:
         installer = profile.graphify_installer
@@ -701,7 +699,7 @@ def _graphify_postinstall(project_root: Path, profiles: list[EditorProfile]) -> 
         if installer in seen:
             continue
         seen.add(installer)
-        graphify_register_with_editor(project_root, console, installer)
+        graphify_register_with_editor(project_root, console_io.console, installer)
 
 
 def _dependency_gate(skip_dep_check: bool) -> bool:
@@ -712,7 +710,7 @@ def _dependency_gate(skip_dep_check: bool) -> bool:
     report.
     """
     missing = check_dependencies()
-    return prompt_or_skip(missing, console, skip=skip_dep_check)
+    return prompt_or_skip(missing, console_io.console, skip=skip_dep_check)
 
 
 def _create_issueflow_dirs(project_root: Path, settings: Settings) -> None:
@@ -722,12 +720,12 @@ def _create_issueflow_dirs(project_root: Path, settings: Settings) -> None:
     for subdir_name in settings.issueflows_subdirs:
         dir_path = base / subdir_name
         if dir_path.exists():
-            console.print(
+            console_io.console.print(
                 f"  [dim]exists[/dim] {settings.issueflows_dir}/{subdir_name}/"
             )
         else:
             dir_path.mkdir(parents=True, exist_ok=True)
-            console.print(
+            console_io.console.print(
                 f"  [green]mkdir[/green]  {settings.issueflows_dir}/{subdir_name}/"
             )
 

--- a/src/issue_flow/init.py
+++ b/src/issue_flow/init.py
@@ -18,7 +18,12 @@ from issue_flow.dependencies import (
 from issue_flow.editors import EditorProfile, resolve_editors
 from issue_flow.graphify import register_with_editor as graphify_register_with_editor
 from issue_flow.modes import Mode
-from issue_flow.step_profiles import enrich_render_context
+from issue_flow.surfaces import (
+    ensure_editor_gitignore,
+    materialize_canonical_store,
+    materialize_editor_profile,
+    write_manifest_files,
+)
 from issue_flow.templating import (
     COMMAND_NAMES,
     RETIRED_COMMANDS,
@@ -118,36 +123,8 @@ def _write_manifest_files(
     *,
     force: bool,
 ) -> tuple[list[Path], list[Path]]:
-    """Render templates from ``manifest`` and write under project_root.
-
-    When ``force`` is False, existing files are skipped (not overwritten).
-    Issue markdown under ``.issueflows/`` is never part of the manifest.
-
-    Returns:
-        (written_relative_paths, skipped_relative_paths)
-    """
-    written_files: list[Path] = []
-    skipped_files: list[Path] = []
-
-    for template_name, path_template in manifest:
-        relative_path = resolve_output_path(path_template, context)
-        absolute_path = project_root / relative_path
-
-        if absolute_path.exists() and not force:
-            console.print(
-                f"  [yellow]skip[/yellow]  {relative_path}  (already exists, use --force to overwrite)"
-            )
-            skipped_files.append(relative_path)
-            continue
-
-        render_context = enrich_render_context(context, template_name)
-        rendered = render_template(template_name, render_context)
-        absolute_path.parent.mkdir(parents=True, exist_ok=True)
-        absolute_path.write_text(rendered, encoding="utf-8")
-        console.print(f"  [green]write[/green] {relative_path}")
-        written_files.append(relative_path)
-
-    return written_files, skipped_files
+    """Backward-compatible wrapper around :func:`surfaces.write_manifest_files`."""
+    return write_manifest_files(project_root, manifest, context, force=force)
 
 
 def _ensure_agents_md(project_root: Path, context: dict[str, str]) -> None:
@@ -275,6 +252,7 @@ def run_init(
     editors: list[str] | None = None,
     mode: str | None = None,
     skill_level: str | None = None,
+    canonical: bool = False,
 ) -> None:
     """Scaffold .issueflows/ directories and editor config (commands, rules, skills).
 
@@ -310,6 +288,10 @@ def run_init(
             When given it is validated and persisted to ``.issueflows/config.toml``
             so later ``update`` runs honour it. When omitted, the persisted/active
             level is used (default ``"standard"``).
+        canonical: When True, scaffold the team-committed canonical store under
+            ``.issueflows/agent/`` instead of per-editor trees, persist
+            ``canonical_format = true``, and append a managed ``.gitignore``
+            block for local editor directories.
     """
     settings = Settings()
     try:
@@ -343,7 +325,10 @@ def run_init(
     console.print(
         f"\n[bold]Initializing issue-flow in [cyan]{project_root}[/cyan][/bold]"
     )
-    console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
+    if canonical:
+        console.print("[dim]Layout: canonical (.issueflows/agent/)[/dim]")
+    else:
+        console.print(f"[dim]Editors: {', '.join(p.id for p in profiles)}[/dim]")
     console.print(f"[dim]Mode: {mode_obj.id}[/dim]")
     console.print(f"[dim]Skill level: {skill_level_id}[/dim]\n")
 
@@ -387,30 +372,50 @@ def run_init(
     written_files: list[Path] = []
     skipped_files: list[Path] = []
     pruned_count = 0
-    for profile in profiles:
-        console.print(
-            f"\n[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
-        )
-        context = settings.template_context(
-            project_root, profile, mode=mode_obj, skill_level=skill_level_id
-        )
-        written, skipped = _write_manifest_files(
+
+    if canonical:
+        console.print("[bold]Canonical store[/bold] (.issueflows/agent/)")
+        result = materialize_canonical_store(
             project_root,
-            build_manifest(profile, mode_obj, skill_level=skill_level_id),
-            context,
+            settings,
+            mode_obj,
+            skill_level_id,
             force=force,
+            ensure_agents_md=_ensure_agents_md,
         )
-        _ensure_agents_md(project_root, context)
-        pruned_count += _prune_retired_files(project_root, profile)
-        pruned_count += _prune_excluded_surfaces(project_root, profile, mode_obj)
-        written_files.extend(written)
-        skipped_files.extend(skipped)
+        written_files.extend(result.written)
+        skipped_files.extend(result.skipped)
+        modes_module.write_canonical_format(cfg_path, True)
+        console.print(
+            f"  [green]write[/green] {cfg_path.relative_to(project_root).as_posix()}  "
+            "(canonical_format = true)"
+        )
+        ensure_editor_gitignore(project_root)
+    else:
+        for profile in profiles:
+            console.print(
+                f"\n[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
+            )
+            result = materialize_editor_profile(
+                project_root,
+                settings,
+                profile,
+                mode_obj,
+                skill_level_id,
+                force=force,
+                prune=True,
+                ensure_agents_md=_ensure_agents_md,
+            )
+            written_files.extend(result.written)
+            skipped_files.extend(result.skipped)
+            pruned_count += result.pruned
 
     console.print()
     _ensure_dotenv_file(project_root)
 
     console.print()
-    _graphify_postinstall(project_root, profiles)
+    if not canonical:
+        _graphify_postinstall(project_root, profiles)
 
     console.print()
     if written_files:
@@ -427,11 +432,15 @@ def run_init(
         console.print("[bold]Nothing to do.[/bold]")
 
     primary = profiles[0]
+    if canonical:
+        hint_dir = f"{settings.issueflows_dir}/agent/skills/"
+    else:
+        hint_dir = f"{primary.agent_dir}/skills/"
     console.print(
         "\n[dim]Run [bold]/iflow-init <number>[/bold] or [bold]/iflow-init[/bold] "
         "(on a branch like [bold]42-slug[/bold], after confirmation) in your editor "
         "to start tracking a GitHub issue. "
-        f"Optional Agent Skills live under [bold]{primary.agent_dir}/skills/[/bold] "
+        f"Optional Agent Skills live under [bold]{hint_dir}[/bold] "
         "([bold]/iflow-init[/bold], etc.).[/dim]\n"
     )
 
@@ -510,19 +519,18 @@ def run_update(
         console.print(
             f"\n[bold]{profile.name}[/bold] ([cyan]{profile.agent_dir}[/cyan])"
         )
-        context = settings.template_context(
-            project_root, profile, mode=mode_obj, skill_level=skill_level_id
-        )
-        written, _skipped = _write_manifest_files(
+        result = materialize_editor_profile(
             project_root,
-            build_manifest(profile, mode_obj, skill_level=skill_level_id),
-            context,
+            settings,
+            profile,
+            mode_obj,
+            skill_level_id,
             force=True,
+            prune=True,
+            ensure_agents_md=_ensure_agents_md,
         )
-        _ensure_agents_md(project_root, context)
-        pruned_count += _prune_retired_files(project_root, profile)
-        pruned_count += _prune_excluded_surfaces(project_root, profile, mode_obj)
-        written_files.extend(written)
+        written_files.extend(result.written)
+        pruned_count += result.pruned
 
     console.print()
     _graphify_postinstall(project_root, profiles)

--- a/src/issue_flow/modes.py
+++ b/src/issue_flow/modes.py
@@ -370,6 +370,30 @@ def read_skill_level(cfg_path: Path) -> str | None:
     return None
 
 
+def read_canonical_format(cfg_path: Path) -> bool | None:
+    """Return the persisted ``[issueflow].canonical_format`` flag."""
+    if not cfg_path.is_file():
+        return None
+    data = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
+    section = data.get("issueflow")
+    if isinstance(section, dict) and "canonical_format" in section:
+        return bool(section.get("canonical_format"))
+    return None
+
+
+def read_persisted_editor(cfg_path: Path) -> str | None:
+    """Return the persisted ``[issueflow].editor`` value."""
+    if not cfg_path.is_file():
+        return None
+    data = tomllib.loads(cfg_path.read_text(encoding="utf-8"))
+    section = data.get("issueflow")
+    if isinstance(section, dict):
+        value = section.get("editor")
+        if value:
+            return str(value)
+    return None
+
+
 def write_active_mode(cfg_path: Path, mode_id: str) -> None:
     """Persist ``[issueflow].mode = mode_id`` while preserving other content.
 
@@ -421,6 +445,38 @@ def write_skill_level(cfg_path: Path, skill_level: str) -> None:
         doc["issueflow"] = section
     section["skill_level"] = skill_level
 
+    cfg_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+
+def write_canonical_format(cfg_path: Path, enabled: bool) -> None:
+    """Persist ``[issueflow].canonical_format`` while preserving other content."""
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    if cfg_path.is_file():
+        doc = tomlkit.parse(cfg_path.read_text(encoding="utf-8"))
+    else:
+        doc = tomlkit.document()
+
+    section = doc.get("issueflow")
+    if not isinstance(section, dict):
+        section = tomlkit.table()
+        doc["issueflow"] = section
+    section["canonical_format"] = enabled
+    cfg_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
+
+
+def write_persisted_editor(cfg_path: Path, editor_id: str) -> None:
+    """Persist ``[issueflow].editor`` while preserving other content."""
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    if cfg_path.is_file():
+        doc = tomlkit.parse(cfg_path.read_text(encoding="utf-8"))
+    else:
+        doc = tomlkit.document()
+
+    section = doc.get("issueflow")
+    if not isinstance(section, dict):
+        section = tomlkit.table()
+        doc["issueflow"] = section
+    section["editor"] = editor_id
     cfg_path.write_text(tomlkit.dumps(doc), encoding="utf-8")
 
 

--- a/src/issue_flow/surfaces.py
+++ b/src/issue_flow/surfaces.py
@@ -9,8 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from rich.console import Console
-
+import issue_flow.console_io as console_io
 from issue_flow.config import Settings
 from issue_flow.editors import EDITORS, EditorProfile, get_profile
 from issue_flow.modes import Mode
@@ -21,8 +20,6 @@ from issue_flow.templating import (
     render_template,
     resolve_output_path,
 )
-
-console = Console()
 
 SurfaceTarget = Literal["editor", "canonical"]
 
@@ -56,7 +53,7 @@ def write_manifest_files(
         absolute_path = project_root / relative_path
 
         if absolute_path.exists() and not force:
-            console.print(
+            console_io.console.print(
                 f"  [yellow]skip[/yellow]  {relative_path}  "
                 "(already exists, use --force to overwrite)"
             )
@@ -67,7 +64,7 @@ def write_manifest_files(
         rendered = render_template(template_name, render_context)
         absolute_path.parent.mkdir(parents=True, exist_ok=True)
         absolute_path.write_text(rendered, encoding="utf-8")
-        console.print(f"  [green]write[/green] {relative_path}")
+        console_io.console.print(f"  [green]write[/green] {relative_path}")
         written_files.append(relative_path)
 
     return written_files, skipped_files
@@ -99,14 +96,14 @@ def write_canonical_manifest_json(
     }
     text = json.dumps(payload, indent=2) + "\n"
     if path.exists() and not force:
-        console.print(
+        console_io.console.print(
             f"  [yellow]skip[/yellow]  {relative}  "
             "(already exists, use --force to overwrite)"
         )
         return None
 
     path.write_text(text, encoding="utf-8")
-    console.print(f"  [green]write[/green] {relative}")
+    console_io.console.print(f"  [green]write[/green] {relative}")
     return relative
 
 
@@ -207,7 +204,7 @@ def prune_other_editor_surfaces(
         agent_root = project_root / profile.agent_dir
         if agent_root.exists():
             shutil.rmtree(agent_root)
-            console.print(f"  [yellow]prune[/yellow]  {agent_root.relative_to(project_root)}/")
+            console_io.console.print(f"  [yellow]prune[/yellow]  {agent_root.relative_to(project_root)}/")
             pruned += 1
         for relative in collect_profile_paths(
             project_root, settings, profile, mode, skill_level
@@ -215,7 +212,7 @@ def prune_other_editor_surfaces(
             absolute = project_root / relative
             if absolute.is_file():
                 absolute.unlink()
-                console.print(f"  [yellow]prune[/yellow]  {relative}")
+                console_io.console.print(f"  [yellow]prune[/yellow]  {relative}")
                 pruned += 1
         if profile.rules_extra:
             _, rules_template = profile.rules_extra
@@ -225,7 +222,7 @@ def prune_other_editor_surfaces(
             rules_path = project_root / resolve_output_path(rules_template, context)
             if rules_path.is_file():
                 rules_path.unlink()
-                console.print(f"  [yellow]prune[/yellow]  {rules_path.relative_to(project_root)}")
+                console_io.console.print(f"  [yellow]prune[/yellow]  {rules_path.relative_to(project_root)}")
                 pruned += 1
     return pruned
 
@@ -257,11 +254,11 @@ def ensure_editor_gitignore(project_root: Path) -> bool:
     if path.exists():
         existing = path.read_text(encoding="utf-8")
         if _GITIGNORE_MARKER_BEGIN in existing:
-            console.print("  [dim]skip[/dim]  .gitignore  (issue-flow editor block present)")
+            console_io.console.print("  [dim]skip[/dim]  .gitignore  (issue-flow editor block present)")
             return False
         updated = existing.rstrip("\n") + "\n\n" + block
     else:
         updated = block
     path.write_text(updated, encoding="utf-8")
-    console.print("  [green]write[/green] .gitignore  (issue-flow editor surfaces)")
+    console_io.console.print("  [green]write[/green] .gitignore  (issue-flow editor surfaces)")
     return True

--- a/src/issue_flow/surfaces.py
+++ b/src/issue_flow/surfaces.py
@@ -1,0 +1,267 @@
+"""Shared scaffolding helpers for init, update, and convert."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from rich.console import Console
+
+from issue_flow.config import Settings
+from issue_flow.editors import EDITORS, EditorProfile, get_profile
+from issue_flow.modes import Mode
+from issue_flow.step_profiles import enrich_render_context
+from issue_flow.templating import (
+    build_canonical_manifest,
+    build_manifest,
+    render_template,
+    resolve_output_path,
+)
+
+console = Console()
+
+SurfaceTarget = Literal["editor", "canonical"]
+
+# Neutral render profile for canonical skill snapshots (skills-first, no rules extra).
+_CANONICAL_RENDER_PROFILE = get_profile("codex")
+
+_GITIGNORE_MARKER_BEGIN = "# BEGIN issue-flow editor surfaces (generated; do not edit)"
+_GITIGNORE_MARKER_END = "# END issue-flow editor surfaces"
+
+
+@dataclass
+class MaterializeResult:
+    written: list[Path]
+    skipped: list[Path]
+    pruned: int
+
+
+def write_manifest_files(
+    project_root: Path,
+    manifest: list[tuple[str, str]],
+    context: dict[str, object],
+    *,
+    force: bool,
+) -> tuple[list[Path], list[Path]]:
+    """Render templates from ``manifest`` and write under ``project_root``."""
+    written_files: list[Path] = []
+    skipped_files: list[Path] = []
+
+    for template_name, path_template in manifest:
+        relative_path = resolve_output_path(path_template, context)
+        absolute_path = project_root / relative_path
+
+        if absolute_path.exists() and not force:
+            console.print(
+                f"  [yellow]skip[/yellow]  {relative_path}  "
+                "(already exists, use --force to overwrite)"
+            )
+            skipped_files.append(relative_path)
+            continue
+
+        render_context = enrich_render_context(context, template_name)
+        rendered = render_template(template_name, render_context)
+        absolute_path.parent.mkdir(parents=True, exist_ok=True)
+        absolute_path.write_text(rendered, encoding="utf-8")
+        console.print(f"  [green]write[/green] {relative_path}")
+        written_files.append(relative_path)
+
+    return written_files, skipped_files
+
+
+def write_canonical_manifest_json(
+    project_root: Path,
+    settings: Settings,
+    mode: Mode,
+    skill_level: str,
+    *,
+    force: bool,
+) -> Path | None:
+    """Write ``.issueflows/agent/manifest.json`` describing the canonical store."""
+    from issue_flow import __version__ as issue_flow_version
+
+    agent_dir = project_root / settings.issueflows_dir / "agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "manifest.json"
+    relative = path.relative_to(project_root)
+
+    payload = {
+        "issue_flow_version": issue_flow_version,
+        "mode": mode.id,
+        "skill_level": skill_level,
+        "skills": sorted(mode.skills),
+        "commands": sorted(mode.commands),
+        "format": "issueflow-canonical-v1",
+    }
+    text = json.dumps(payload, indent=2) + "\n"
+    if path.exists() and not force:
+        console.print(
+            f"  [yellow]skip[/yellow]  {relative}  "
+            "(already exists, use --force to overwrite)"
+        )
+        return None
+
+    path.write_text(text, encoding="utf-8")
+    console.print(f"  [green]write[/green] {relative}")
+    return relative
+
+
+def materialize_editor_profile(
+    project_root: Path,
+    settings: Settings,
+    profile: EditorProfile,
+    mode: Mode,
+    skill_level: str,
+    *,
+    force: bool,
+    prune: bool,
+    ensure_agents_md: Callable[[Path, dict[str, object]], None],
+) -> MaterializeResult:
+    """Render and write one editor profile's scaffold surfaces."""
+    from issue_flow.init import (
+        _prune_excluded_surfaces,
+        _prune_retired_files,
+    )
+
+    context = settings.template_context(
+        project_root, profile, mode=mode, skill_level=skill_level
+    )
+    written, skipped = write_manifest_files(
+        project_root,
+        build_manifest(profile, mode, skill_level=skill_level),
+        context,
+        force=force,
+    )
+    ensure_agents_md(project_root, context)
+    pruned = 0
+    if prune:
+        pruned += _prune_retired_files(project_root, profile)
+        pruned += _prune_excluded_surfaces(project_root, profile, mode)
+    return MaterializeResult(written=written, skipped=skipped, pruned=pruned)
+
+
+def materialize_canonical_store(
+    project_root: Path,
+    settings: Settings,
+    mode: Mode,
+    skill_level: str,
+    *,
+    force: bool,
+    ensure_agents_md: Callable[[Path, dict[str, object]], None],
+) -> MaterializeResult:
+    """Render editor-neutral skills into ``.issueflows/agent/``."""
+    context = settings.template_context(
+        project_root,
+        _CANONICAL_RENDER_PROFILE,
+        mode=mode,
+        skill_level=skill_level,
+    )
+    written, skipped = write_manifest_files(
+        project_root,
+        build_canonical_manifest(mode, skill_level=skill_level),
+        context,
+        force=force,
+    )
+    ensure_agents_md(project_root, context)
+    manifest_path = write_canonical_manifest_json(
+        project_root, settings, mode, skill_level, force=force
+    )
+    if manifest_path is not None:
+        written.append(manifest_path)
+    return MaterializeResult(written=written, skipped=skipped, pruned=0)
+
+
+def collect_profile_paths(
+    project_root: Path,
+    settings: Settings,
+    profile: EditorProfile,
+    mode: Mode,
+    skill_level: str,
+) -> list[Path]:
+    """Return manifest output paths for ``profile`` (files and parent dirs)."""
+    context = settings.template_context(
+        project_root, profile, mode=mode, skill_level=skill_level
+    )
+    paths: list[Path] = []
+    for _, path_template in build_manifest(profile, mode, skill_level=skill_level):
+        paths.append(resolve_output_path(path_template, context))
+    return paths
+
+
+def prune_other_editor_surfaces(
+    project_root: Path,
+    settings: Settings,
+    keep_profile: EditorProfile | None,
+    mode: Mode,
+    skill_level: str,
+) -> int:
+    """Remove scaffold trees for every editor profile except ``keep_profile``."""
+    pruned = 0
+    for editor_id, profile in EDITORS.items():
+        if keep_profile is not None and profile.id == keep_profile.id:
+            continue
+        agent_root = project_root / profile.agent_dir
+        if agent_root.exists():
+            shutil.rmtree(agent_root)
+            console.print(f"  [yellow]prune[/yellow]  {agent_root.relative_to(project_root)}/")
+            pruned += 1
+        for relative in collect_profile_paths(
+            project_root, settings, profile, mode, skill_level
+        ):
+            absolute = project_root / relative
+            if absolute.is_file():
+                absolute.unlink()
+                console.print(f"  [yellow]prune[/yellow]  {relative}")
+                pruned += 1
+        if profile.rules_extra:
+            _, rules_template = profile.rules_extra
+            context = settings.template_context(
+                project_root, profile, mode=mode, skill_level=skill_level
+            )
+            rules_path = project_root / resolve_output_path(rules_template, context)
+            if rules_path.is_file():
+                rules_path.unlink()
+                console.print(f"  [yellow]prune[/yellow]  {rules_path.relative_to(project_root)}")
+                pruned += 1
+    return pruned
+
+
+def prune_all_editor_surfaces(
+    project_root: Path,
+    settings: Settings,
+    mode: Mode,
+    skill_level: str,
+) -> int:
+    """Remove every known editor scaffold tree."""
+    return prune_other_editor_surfaces(
+        project_root, settings, keep_profile=None, mode=mode, skill_level=skill_level
+    )
+
+def ensure_editor_gitignore(project_root: Path) -> bool:
+    """Append gitignore entries for local-only editor dirs. Returns True if changed."""
+    lines = [
+        _GITIGNORE_MARKER_BEGIN,
+        ".cursor/",
+        ".claude/",
+        ".opencode/",
+        ".codex/",
+        _GITIGNORE_MARKER_END,
+        "",
+    ]
+    block = "\n".join(lines)
+    path = project_root / ".gitignore"
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if _GITIGNORE_MARKER_BEGIN in existing:
+            console.print("  [dim]skip[/dim]  .gitignore  (issue-flow editor block present)")
+            return False
+        updated = existing.rstrip("\n") + "\n\n" + block
+    else:
+        updated = block
+    path.write_text(updated, encoding="utf-8")
+    console.print("  [green]write[/green] .gitignore  (issue-flow editor surfaces)")
+    return True

--- a/src/issue_flow/templating.py
+++ b/src/issue_flow/templating.py
@@ -212,6 +212,39 @@ DOCS_ENTRY: tuple[str, str] = (
 )
 
 
+def build_canonical_manifest(
+    mode: Mode | None = None, skill_level: str | None = None
+) -> list[tuple[str, str]]:
+    """Return skill-only manifest entries under ``.issueflows/agent/skills/``.
+
+    Canonical snapshots use editor-neutral skill bodies (rendered with the codex
+    profile context) and omit per-editor rules, commands, and workflow docs.
+    """
+    skills_filter = None if mode is None else mode.skills
+    entries: list[tuple[str, str]] = []
+
+    for skill_dir in SKILL_DIRS:
+        if skills_filter is not None and skill_dir not in skills_filter:
+            continue
+        output_name = SKILL_OUTPUT_NAMES.get(skill_dir, skill_dir.replace("_", "-"))
+        entries.append(
+            (
+                f"skills/{skill_dir}/SKILL.md.j2",
+                "{issueflows_dir}/agent/skills/" + f"{output_name}/SKILL.md",
+            )
+        )
+
+    if skill_level == "advanced":
+        entries.append(
+            (
+                "designs/python-quality-tools.md.j2",
+                "{issueflows_dir}/{designs_folder}/python-quality-tools.md",
+            )
+        )
+
+    return entries
+
+
 def build_manifest(
     profile: EditorProfile, mode: Mode | None = None, skill_level: str | None = None
 ) -> list[tuple[str, str]]:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,0 +1,67 @@
+"""Tests for issue_flow.convert and canonical scaffolding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from issue_flow.convert import run_convert
+from issue_flow.init import run_init
+from issue_flow.templating import build_canonical_manifest, build_manifest
+from issue_flow.editors import get_profile
+
+
+def test_build_canonical_manifest_is_skill_only() -> None:
+    manifest = build_canonical_manifest()
+    cursor_manifest = build_manifest(get_profile("cursor"))
+    assert all("agent/skills" in path for _, path in manifest)
+    assert all(template.startswith("skills/") for template, _ in manifest)
+    assert len(manifest) < len(cursor_manifest)
+
+
+def test_init_canonical_creates_agent_store(tmp_path: Path) -> None:
+    run_init(tmp_path, canonical=True, skip_dep_check=True)
+
+    agent_skills = tmp_path / ".issueflows" / "agent" / "skills"
+    assert agent_skills.is_dir()
+    assert (agent_skills / "iflow-init" / "SKILL.md").is_file()
+    assert (tmp_path / ".issueflows" / "agent" / "manifest.json").is_file()
+    assert (tmp_path / "AGENTS.md").is_file()
+    assert not (tmp_path / ".cursor").exists()
+
+    config = (tmp_path / ".issueflows" / "config.toml").read_text(encoding="utf-8")
+    assert "canonical_format = true" in config
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ".cursor/" in gitignore
+    assert ".claude/" in gitignore
+
+
+def test_convert_to_editor_materializes_cursor_tree(tmp_path: Path) -> None:
+    run_init(tmp_path, canonical=True, skip_dep_check=True)
+
+    run_convert(tmp_path, to="cursor", force=True)
+
+    skills = tmp_path / ".cursor" / "skills" / "iflow-init" / "SKILL.md"
+    assert skills.is_file()
+    assert (tmp_path / ".cursor" / "rules" / "issueflow-rules.mdc").is_file()
+
+
+def test_convert_to_canonical_prunes_editor_dirs(tmp_path: Path) -> None:
+    run_init(tmp_path, skip_dep_check=True)
+    assert (tmp_path / ".cursor").exists()
+
+    run_convert(tmp_path, to="canonical", force=True, prune_other=True)
+
+    assert (tmp_path / ".issueflows" / "agent" / "skills" / "iflow-init" / "SKILL.md").is_file()
+    assert not (tmp_path / ".cursor").exists()
+
+
+def test_convert_prune_other_removes_sibling_editors(tmp_path: Path) -> None:
+    run_init(tmp_path, editors=["cursor", "claude"], skip_dep_check=True)
+    assert (tmp_path / ".cursor").exists()
+    assert (tmp_path / ".claude").exists()
+
+    run_convert(tmp_path, to="cursor", force=True, prune_other=True)
+
+    assert (tmp_path / ".cursor").exists()
+    assert not (tmp_path / ".claude").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 1** of [#23](https://github.com/jepegit/issue-flow/issues/23): mixed-editor teams can commit a canonical agent layout and materialize local editor surfaces on demand.

## Changes

- **Canonical store** — `.issueflows/agent/skills/` + `manifest.json` (portable `SKILL.md` snapshots)
- **`issue-flow convert`** — `--to cursor|claude|opencode|codex|canonical`, plus `--prune-other` and `--gitignore`
- **`issue-flow init --canonical`** — team bootstrap; managed `.gitignore` block for local editor dirs
- **Refactor** — shared scaffold logic in `src/issue_flow/surfaces.py` (used by init/update/convert)
- **Config** — `canonical_format` and persisted `editor` keys in `config.toml`
- **Docs** — `docs/configuration.md` + `.issueflows/04-designs-and-guides/multi-editor-conversion.md`

## Deferred (Phase 2)

Opt-in git hooks for automatic pull/push conversion (#23 step 5).

## Test plan

- [x] `uv run pytest tests/test_convert.py` (5 tests)
- [x] `uv run pytest tests/test_init.py tests/test_templating.py` (regression)
- [x] `uv run ruff check src/ tests/`
- [x] Manual: `issue-flow init --canonical` → `convert --to claude` on throwaway repo

Closes #23 (phase 1 scope).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5aa1-5d97-738b-bd00-79b18852affb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5aa1-5d97-738b-bd00-79b18852affb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

