### PR TITLE
Fix docs site logo and iPhone CLI visibility (#162)

### DIFF
--- a/.issueflows/03-solved-issues/issue162_original.md
+++ b/.issueflows/03-solved-issues/issue162_original.md
@@ -1,0 +1,7 @@
+# Issue #162: Docs check
+
+Source: https://github.com/jepegit/issue-flow/issues/162
+
+## Original issue text
+
+The CLI chapter does not show on my iPhone, same with the issueflow icon.

--- a/.issueflows/03-solved-issues/issue162_plan.md
+++ b/.issueflows/03-solved-issues/issue162_plan.md
@@ -1,0 +1,43 @@
+# Issue #162 plan: Docs check (iPhone)
+
+## Goal
+
+Fix the published Zensical docs on iPhone: restore the header logo/favicon and make the CLI reference page reliably visible on mobile Safari.
+
+## Constraints
+
+- Docs-only change; no scaffold templates or CLI code.
+- Keep nav structure and existing logo assets; do not reintroduce removed PNGs.
+- Prefer minimal, targeted fixes over broad theme rewrites.
+
+### Prior art
+
+- [zensical.toml](zensical.toml) — `logo` points at missing `static/images/logo-pblue.svg` (commit `bf96830` changed path, file never added). Existing blue asset: `logo-light-right-color.svg`.
+- [issue #151 plan](.issueflows/03-solved-issues/issue151_plan.md) — favicon deliberately skipped; issue #162 reports icon missing on phone.
+- [docs/cli.md](docs/cli.md) — opens with a wide, unwrapped synopsis code block; `navigation.instant` + `navigation.instant.prefetch` enabled (known Safari SPA nav bugs).
+- Toolbox — no doc-site helper.
+
+## Approach
+
+1. **Logo** — point `[project.theme] logo` at `static/images/logo-light-right-color.svg` (the committed blue gradient icon).
+2. **Favicon** — set `favicon = "static/images/logo-black.svg"` so mobile tabs/bookmarks show the mark.
+3. **Mobile CLI reliability** — drop `navigation.instant` and `navigation.instant.prefetch` from theme features (Safari/iPhone blank-page / dead-link reports with instant loading).
+4. **Mobile overflow CSS** — add `docs/stylesheets/extra.css` via `extra_css`; enable horizontal scroll + touch momentum for wide `pre` blocks and tables.
+5. **CLI synopsis** — add YAML frontmatter title; rewrap the opening command synopsis onto shorter lines so the block does not force horizontal overflow on narrow viewports.
+
+## Files to touch
+
+| File | Change |
+| --- | --- |
+| [zensical.toml](zensical.toml) | Fix logo path, add favicon, drop instant nav features, register `extra_css` |
+| [docs/stylesheets/extra.css](docs/stylesheets/extra.css) | New — mobile overflow rules for code + tables |
+| [docs/cli.md](docs/cli.md) | Frontmatter + wrapped synopsis block |
+
+## Test strategy
+
+- `uv run zensical build` — succeeds; built HTML references existing logo SVG and includes `extra.css`.
+- `uv run pytest` — regression safety (no new tests; docs-only).
+
+## Open questions
+
+- None — scope is small and yolo-appropriate.

--- a/.issueflows/03-solved-issues/issue162_status.md
+++ b/.issueflows/03-solved-issues/issue162_status.md
@@ -1,0 +1,16 @@
+# Issue #162 — status
+
+- [x] Done
+
+## What's done
+
+- Fixed missing logo: `zensical.toml` now points at committed `logo-light-right-color.svg`
+- Added favicon (`logo-black.svg`) for mobile tabs/bookmarks
+- Removed `navigation.instant` + prefetch (Safari blank-page workaround)
+- Added `docs/stylesheets/extra.css` for mobile code/table overflow
+- Wrapped CLI synopsis block + YAML frontmatter in `docs/cli.md`
+- `zensical build` OK; 481 tests pass
+
+## Remaining work
+
+- None

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,8 @@ than the GitHub release notes they link to.
 
 ## [Unreleased]
 
+- **Docs site iPhone fixes (#162).** Point the Zensical theme logo at the committed blue SVG, add a favicon, drop instant navigation (Safari blank-page workaround), add mobile overflow CSS for wide CLI blocks/tables, and rewrap the CLI synopsis.
+
 - **Multi-editor canonical store and convert CLI (#23).** Phase 1 for mixed-editor teams: team-committed `.issueflows/agent/` skill snapshots, `issue-flow convert --to <editor|canonical>` (with `--prune-other` / `--gitignore`), `init --canonical`, shared scaffold logic in `surfaces.py`, and `console_io` so `workspace update --json` stays machine-readable. Git-hook automation deferred to follow-up.
 
 - **GitHub Actions sync (#102).** New `issue-flow sync` command (dry-run by default, `--apply` pushes via `gh`) maps `.issueflows/` folder placement (`01-current` / `02-partly-solved` / `03-solved`) to managed `status:*` labels on GitHub (one-way; unrelated labels preserved). Configurable via `[issueflow.sync]` in `config.toml`. Ships a reusable `workflow_call` workflow (`.github/workflows/issue-flow-sync.yml`) plus a dogfood caller on this repo; README documents enablement and label bootstrap.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,12 @@
+---
+title: CLI reference
+---
+
 # CLI reference
 
-```
-issue-flow init [PROJECT_DIR] [--force] [--skip-dep-check] [--editor EDITOR] [--mode MODE] [--skill-level LEVEL]
+```text
+issue-flow init [PROJECT_DIR] [--force] [--skip-dep-check]
+  [--editor EDITOR] [--mode MODE] [--skill-level LEVEL]
 issue-flow update [PROJECT_DIR] [--skip-dep-check] [--editor EDITOR]
 issue-flow graphify [-C PROJECT_DIR] [...graphify subcommand + args]
 issue-flow status [PROJECT_DIR] [--local] [--json]
@@ -14,9 +19,11 @@ issue-flow agent queue [N ...] [--label L] [--epic N] [-C PROJECT_DIR] [--json]
 issue-flow agent resolve [-C PROJECT_DIR] [--from-file FILE] [--json]
 issue-flow agent sweep [PROJECT_DIR] [--except N] [--dry-run] [--json]
 issue-flow agent archive N [N ...] [-C PROJECT_DIR] [--dry-run] [--json]
-issue-flow agent capture N [-C PROJECT_DIR] [--repo OWNER/REPO] [--force] [--json]
+issue-flow agent capture N [-C PROJECT_DIR] [--repo OWNER/REPO]
+  [--force] [--json]
 issue-flow config add [-C PROJECT_DIR] [--force] [--json]
-issue-flow workspace init [WORKSPACE_DIR] [--default MEMBER] [--force] [--json]
+issue-flow workspace init [WORKSPACE_DIR] [--default MEMBER]
+  [--force] [--json]
 ```
 
 ## When to use which

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,18 @@
+/* Mobile-friendly overflow for wide CLI synopsis blocks and tables. */
+
+.md-typeset pre > code {
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+.md-typeset .highlight pre,
+.md-typeset pre {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.md-typeset table:not([class]) {
+  display: block;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}

--- a/zensical.toml
+++ b/zensical.toml
@@ -34,8 +34,11 @@ nav = [
   { "Acknowledgements" = "acknowledgements.md" },
 ]
 
+extra_css = ["stylesheets/extra.css"]
+
 [project.theme]
-logo = "static/images/logo-pblue.svg"
+logo = "static/images/logo-light-right-color.svg"
+favicon = "static/images/logo-black.svg"
 language = "en"
 
 features = [
@@ -51,8 +54,6 @@ features = [
     # back-to-top, and anchor tracking.
     "navigation.footer",
     "navigation.indexes",
-    "navigation.instant",
-    "navigation.instant.prefetch",
     "navigation.path",
     "navigation.sections",
     "navigation.top",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #162

## Problem

On iPhone, the issue-flow docs showed no header logo and the CLI reference page could appear blank or unusable.

## Root cause

- `zensical.toml` pointed at `static/images/logo-pblue.svg`, which was never committed (only `logo-light-right-color.svg` and siblings exist).
- `navigation.instant` + prefetch are known to misbehave on mobile Safari (blank pages / dead nav links).
- The CLI synopsis opened with very long unwrapped lines, forcing horizontal overflow on narrow viewports.

## Fix

- Point theme `logo` at `logo-light-right-color.svg` and set `favicon` to `logo-black.svg`.
- Remove instant navigation features.
- Add `docs/stylesheets/extra.css` with mobile-friendly overflow for code blocks and tables.
- Add CLI frontmatter and rewrap the synopsis block.

## How to test

```bash
uv sync --group docs
uv run zensical build
# Inspect site/index.html — logo src should resolve; extra.css linked; no navigation.instant
uv run pytest
```

After RTD rebuild, verify on iPhone: header logo visible, CLI reference nav link loads content.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5ace-454f-7606-918a-5f66afdb388a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5ace-454f-7606-918a-5f66afdb388a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

